### PR TITLE
chore: align repo URLs to backbay-labs/clawdstrike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,4 +120,4 @@ Initial alpha release. APIs and import paths will change before 1.0.
 - Release builds with LTO
 - Dependabot configured for automated security updates
 
-[Unreleased]: https://github.com/backbay-labs/hushclaw/compare/main...HEAD
+[Unreleased]: https://github.com/backbay-labs/clawdstrike/compare/main...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,12 @@ Optional for specific packages:
 1. Fork the repository on GitHub
 2. Clone your fork:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/hushclaw.git
-   cd hushclaw
+   git clone https://github.com/YOUR_USERNAME/clawdstrike.git
+   cd clawdstrike
    ```
 3. Add upstream remote:
    ```bash
-   git remote add upstream https://github.com/backbay-labs/hushclaw.git
+   git remote add upstream https://github.com/backbay-labs/clawdstrike.git
    ```
 
 ### Development Setup
@@ -214,7 +214,7 @@ By contributing, you agree that your contributions will be licensed under the MI
 
 ## Questions?
 
-- Open a [GitHub Discussion](https://github.com/backbay-labs/hushclaw/discussions) for questions
+- Open a [GitHub Discussion](https://github.com/backbay-labs/clawdstrike/discussions) for questions
 - Join our community chat (coming soon)
 
 Thank you for contributing!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["fuzz", "examples/rust/basic-verification"]
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/backbay-labs/hushclaw"
+repository = "https://github.com/backbay-labs/clawdstrike"
 rust-version = "1.92"
 
 [workspace.dependencies]

--- a/HomebrewFormula/hush.rb
+++ b/HomebrewFormula/hush.rb
@@ -4,15 +4,15 @@
 #
 # SHA256 is automatically updated by the release workflow.
 # To calculate SHA256 manually:
-#   curl -sL https://github.com/backbay-labs/hushclaw/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+#   curl -sL https://github.com/backbay-labs/clawdstrike/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 class Hush < Formula
   desc "CLI for clawdstrike security verification and policy enforcement"
-  homepage "https://github.com/backbay-labs/hushclaw"
-  url "https://github.com/backbay-labs/hushclaw/archive/refs/tags/v0.1.0.tar.gz"
+  homepage "https://github.com/backbay-labs/clawdstrike"
+  url "https://github.com/backbay-labs/clawdstrike/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "PLACEHOLDER_SHA256_WILL_BE_UPDATED_ON_RELEASE"
   license "MIT"
-  head "https://github.com/backbay-labs/hushclaw.git", branch: "main"
+  head "https://github.com/backbay-labs/clawdstrike.git", branch: "main"
 
   depends_on "rust" => :build
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/backbay-labs/hushclaw/actions"><img src="https://img.shields.io/github/actions/workflow/status/backbay-labs/hushclaw/ci.yml?branch=main&style=flat-square&logo=github&label=CI" alt="CI Status"></a>
+  <a href="https://github.com/backbay-labs/clawdstrike/actions"><img src="https://img.shields.io/github/actions/workflow/status/backbay-labs/clawdstrike/ci.yml?branch=main&style=flat-square&logo=github&label=CI" alt="CI Status"></a>
   <a href="https://crates.io/crates/clawdstrike"><img src="https://img.shields.io/crates/v/clawdstrike?style=flat-square&logo=rust" alt="crates.io"></a>
   <a href="https://docs.rs/clawdstrike"><img src="https://img.shields.io/docsrs/clawdstrike?style=flat-square&logo=docs.rs" alt="docs.rs"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License: MIT"></a>
@@ -144,7 +144,7 @@ No external API calls required for core detection. [Full benchmarks →](docs/sr
 We take security seriously. If you discover a vulnerability:
 
 - **For sensitive issues**: Email [connor@backbay.io](mailto:connor@backbay.io) with details. We aim to respond within 48 hours.
-- **For non-sensitive issues**: Open a [GitHub issue](https://github.com/backbay-labs/hushclaw/issues) with the `security` label.
+- **For non-sensitive issues**: Open a [GitHub issue](https://github.com/backbay-labs/clawdstrike/issues) with the `security` label.
 
 ## Contributing
 

--- a/crates/hush-wasm/package.json
+++ b/crates/hush-wasm/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/backbay-labs/hushclaw.git",
+    "url": "https://github.com/backbay-labs/clawdstrike.git",
     "directory": "crates/hush-wasm"
   },
   "keywords": [
@@ -28,7 +28,7 @@
   "author": "Clawdstrike Contributors",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/backbay-labs/hushclaw/issues"
+    "url": "https://github.com/backbay-labs/clawdstrike/issues"
   },
   "homepage": "https://clawdstrike.dev"
 }

--- a/deploy/systemd/hushd.service
+++ b/deploy/systemd/hushd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Clawdstrike Security Daemon
-Documentation=https://github.com/backbay-labs/hushclaw
+Documentation=https://github.com/backbay-labs/clawdstrike
 After=network.target
 Wants=network-online.target
 

--- a/deploy/systemd/hushd@.service
+++ b/deploy/systemd/hushd@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Clawdstrike Security Daemon (%i instance)
-Documentation=https://github.com/backbay-labs/hushclaw
+Documentation=https://github.com/backbay-labs/clawdstrike
 After=network.target
 Wants=network-online.target
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -11,8 +11,8 @@ build-dir = "book"
 [output.html]
 default-theme = "navy"
 preferred-dark-theme = "navy"
-git-repository-url = "https://github.com/backbay-labs/hushclaw"
-edit-url-template = "https://github.com/backbay-labs/hushclaw/edit/main/docs/{path}"
+git-repository-url = "https://github.com/backbay-labs/clawdstrike"
+edit-url-template = "https://github.com/backbay-labs/clawdstrike/edit/main/docs/{path}"
 additional-css = ["theme/custom.css"]
 
 [output.html.fold]

--- a/docs/src/guides/openclaw-integration.md
+++ b/docs/src/guides/openclaw-integration.md
@@ -17,7 +17,7 @@ This is **not** an OS sandbox and does not intercept syscalls. If an agent/runti
 
 ```bash
 # Link the local package
-openclaw plugins install --link /path/to/hushclaw/packages/clawdstrike-openclaw
+openclaw plugins install --link /path/to/clawdstrike/packages/clawdstrike-openclaw
 
 # Enable the plugin
 openclaw plugins enable clawdstrike-security

--- a/packages/clawdstrike-openclaw/docs/getting-started.md
+++ b/packages/clawdstrike-openclaw/docs/getting-started.md
@@ -17,7 +17,7 @@ This is **not** an OS sandbox. If an agent/runtime can access the filesystem/net
 
 ```bash
 # Link the local package
-openclaw plugins install --link /path/to/hushclaw/packages/clawdstrike-openclaw
+openclaw plugins install --link /path/to/clawdstrike/packages/clawdstrike-openclaw
 
 # Enable the plugin
 openclaw plugins enable clawdstrike-security

--- a/packages/hush-ts/package.json
+++ b/packages/hush-ts/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/backbay-labs/hushclaw.git",
+    "url": "https://github.com/backbay-labs/clawdstrike.git",
     "directory": "packages/hush-ts"
   },
   "dependencies": {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -81,7 +81,7 @@ fi
 
 if [[ -f "HomebrewFormula/hush.rb" ]]; then
     echo "  Updating HomebrewFormula/hush.rb tag URL..."
-    $SED_INPLACE "s#https://github.com/backbay-labs/hushclaw/archive/refs/tags/v[0-9][0-9.]*\\.tar\\.gz#https://github.com/backbay-labs/hushclaw/archive/refs/tags/v$VERSION.tar.gz#" HomebrewFormula/hush.rb
+    $SED_INPLACE "s#https://github.com/backbay-labs/clawdstrike/archive/refs/tags/v[0-9][0-9.]*\\.tar\\.gz#https://github.com/backbay-labs/clawdstrike/archive/refs/tags/v$VERSION.tar.gz#" HomebrewFormula/hush.rb
 fi
 
 # Update pyproject.toml if it exists

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -81,7 +81,7 @@ for pkg in [
 
 formula = (repo_root / "HomebrewFormula/hush.rb").read_text(encoding="utf-8")
 match = re.search(
-    r'^\s*url\s+"https://github\.com/backbay-labs/hushclaw/archive/refs/tags/v([^"]+)\.tar\.gz"\s*$',
+    r'^\s*url\s+"https://github\.com/backbay-labs/clawdstrike/archive/refs/tags/v([^"]+)\.tar\.gz"\s*$',
     formula,
     flags=re.M,
 )


### PR DESCRIPTION
Updates Cargo/package metadata, docs, and release scripts to consistently point at the current GitHub repo (backbay-labs/clawdstrike).