### PR TITLE
fix(ci): gate Artifact Hub publish without job-level secrets

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -69,20 +69,34 @@ jobs:
     name: Publish Artifact Hub Metadata
     runs-on: ubuntu-latest
     needs: publish-oci
-    if: ${{ secrets.ARTIFACTHUB_REPOSITORY_ID != '' }}
+    env:
+      ARTIFACTHUB_REPOSITORY_ID: ${{ secrets.ARTIFACTHUB_REPOSITORY_ID }}
     steps:
+      - name: Gate Artifact Hub publish
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${ARTIFACTHUB_REPOSITORY_ID:-}" ]]; then
+            echo "Artifact Hub repository ID secret not set; skipping publish." >> "$GITHUB_STEP_SUMMARY"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
       - name: Setup ORAS
+        if: steps.gate.outputs.should_publish == 'true'
         uses: oras-project/setup-oras@v1
 
       - name: Login to GHCR for ORAS
+        if: steps.gate.outputs.should_publish == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: echo "$GITHUB_TOKEN" | oras login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
 
       - name: Push artifacthub-repo metadata
-        env:
-          ARTIFACTHUB_REPOSITORY_ID: ${{ secrets.ARTIFACTHUB_REPOSITORY_ID }}
+        if: steps.gate.outputs.should_publish == 'true'
         run: |
           cat > artifacthub-repo.yml <<EOF
           repositoryID: ${ARTIFACTHUB_REPOSITORY_ID}


### PR DESCRIPTION
Fixes helm-release workflow validation failure by removing job-level `if:` that referenced `secrets.*` (not allowed in that expression context).\n\nWe now gate the Artifact Hub metadata publish inside steps using a small bash gate step, so the workflow parses and runs regardless of whether `ARTIFACTHUB_REPOSITORY_ID` is set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI workflow change that only affects whether Artifact Hub metadata publish steps run when a secret is missing; no product code or data paths are impacted.
> 
> **Overview**
> Fixes `helm-release.yml` validation by removing the job-level `if:` that referenced `secrets.*` for the Artifact Hub publish job.
> 
> Adds a bash gating step that checks `ARTIFACTHUB_REPOSITORY_ID` and conditionally runs the ORAS setup/login and metadata push steps, while writing a skip message to the job summary when the secret is absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8986a50de80c449996968a15497ac4e821934ec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->