### PR TITLE
fix(ci): publish Artifact Hub metadata to chart OCI repo

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -17,6 +17,7 @@ permissions:
 
 env:
   HELM_OCI_REPO: oci://ghcr.io/backbay-labs/clawdstrike/helm
+  CHART_NAME: clawdstrike
 
 jobs:
   publish-oci:
@@ -101,6 +102,9 @@ jobs:
           cat > artifacthub-repo.yml <<EOF
           repositoryID: ${ARTIFACTHUB_REPOSITORY_ID}
           EOF
-          oras push ghcr.io/backbay-labs/clawdstrike/helm:artifacthub.io \
+          # Helm pushes charts to <repo>/<chartName>:<version>. Publish Artifact Hub metadata to the
+          # same OCI repository where the chart lives.
+          OCI_REPO_PATH="${HELM_OCI_REPO#oci://}"
+          oras push "${OCI_REPO_PATH}/${CHART_NAME}:artifacthub.io" \
             --config /dev/null:application/vnd.cncf.artifact.config.v1+json \
             artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml


### PR DESCRIPTION
Helm OCI charts live at `<repo>/<chartName>:<version>` (for us: `ghcr.io/backbay-labs/clawdstrike/helm/clawdstrike:<version>`).\n\nThe Artifact Hub metadata ORAS push was targeting `.../helm:artifacthub.io` which is the namespace prefix and fails with 403. This updates the workflow to push to `.../helm/clawdstrike:artifacthub.io`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts the ORAS destination path; low risk aside from potentially impacting chart metadata publishing if misconfigured.
> 
> **Overview**
> Updates the Helm release GitHub Actions workflow to publish `artifacthub-repo.yml` to the *same OCI path as the chart* (i.e., `<repo>/<chartName>:artifacthub.io`) instead of pushing to the repository prefix tag.
> 
> This adds `CHART_NAME` and derives `OCI_REPO_PATH` from `HELM_OCI_REPO` to construct the correct `oras push` target, avoiding failed publishes due to an incorrect GHCR destination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc552d4debf3e9a5fc3c7aaae38424e1d5ceabff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->