### PR TITLE
fix(ci): Artifact Hub badge + ORAS media type

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -106,5 +106,5 @@ jobs:
           # same OCI repository where the chart lives.
           OCI_REPO_PATH="${HELM_OCI_REPO#oci://}"
           oras push "${OCI_REPO_PATH}/${CHART_NAME}:artifacthub.io" \
-            --config /dev/null:application/vnd.cncf.artifact.config.v1+json \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
             artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ docs/book
 # Local release artifacts
 dist/
 
+# Local diagnostics bundles
+_diag/
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a href="https://github.com/backbay-labs/clawdstrike/actions"><img src="https://img.shields.io/github/actions/workflow/status/backbay-labs/clawdstrike/ci.yml?branch=main&style=flat-square&logo=github&label=CI" alt="CI Status"></a>
   <a href="https://crates.io/crates/libs/clawdstrike"><img src="https://img.shields.io/crates/v/clawdstrike?style=flat-square&logo=rust" alt="crates.io"></a>
   <a href="https://docs.rs/clawdstrike"><img src="https://img.shields.io/docsrs/clawdstrike?style=flat-square&logo=docs.rs" alt="docs.rs"></a>
+  <a href="https://artifacthub.io/packages/search?repo=clawdstrike"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/clawdstrike" alt="Artifact Hub"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License: Apache-2.0"></a>
   <img src="https://img.shields.io/badge/MSRV-1.93-orange?style=flat-square&logo=rust" alt="MSRV: 1.93">
 </p>


### PR DESCRIPTION
Changes:
- Align ORAS config media type with Artifact Hub OCI guidance.
- Add Artifact Hub badge to README.
- Ignore local _diag bundles.

Notes:
- Artifact Hub indexing requires anonymous pulls. Make GHCR chart package public and set Artifact Hub repo URL to `oci://ghcr.io/backbay-labs/clawdstrike/helm/clawdstrike`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow metadata change plus documentation/gitignore updates; low blast radius, with main risk being a misconfigured publish step if the media type is still incorrect.
> 
> **Overview**
> Fixes Helm chart publishing to Artifact Hub by updating the `oras push` config media type in `helm-release.yml` to the Artifact Hub OCI-recommended value.
> 
> Adds an Artifact Hub badge link to `README.md` and updates `.gitignore` to exclude local diagnostics bundles in `_diag/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97485c82e9286d7b42d69f613a244b15034959c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->