### PR TITLE
chore: fix CI vendor mismatch and resolve CodeQL findings

### DIFF
--- a/crates/services/hushd/tests/cua_policy_events.rs
+++ b/crates/services/hushd/tests/cua_policy_events.rs
@@ -49,9 +49,8 @@ fn cua_events_map_to_custom_guard_action() {
 
     for (event_type, cua_action) in cases {
         let event = cua_event(event_type, base_cua_data(cua_action));
-        let mapped = map_policy_event(&event).unwrap_or_else(|_| {
-            panic!("map_policy_event should succeed for {}", event_type)
-        });
+        let mapped = map_policy_event(&event)
+            .unwrap_or_else(|_| panic!("map_policy_event should succeed for {}", event_type));
 
         match &mapped.action {
             MappedGuardAction::Custom { custom_type, .. } => {


### PR DESCRIPTION
## Summary
- Re-vendor Cargo dependencies to fix chrono 0.4.43 → 0.4.44 mismatch causing offline build failure
- Fix all non-vendor CodeQL findings across Python and TypeScript (unused imports/variables, empty excepts, NaN check idiom, redundant assignments, no-effect statements, mixed import styles)
- Fix Clippy `expect_fun_call` lint in hushd test
- Add CodeQL config to exclude `infra/vendor` from analysis

## Test plan
- [ ] Offline Build/Test (vendored) job passes
- [ ] Clippy passes with `-D warnings`
- [ ] All existing tests pass
- [ ] CodeQL vendor findings no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only formatting/lint refactor with no runtime or behavior changes expected.
> 
> **Overview**
> Refactors `cua_policy_events` integration test code to satisfy Clippy’s `expect_fun_call`/closure-style lint by collapsing the `unwrap_or_else` panic into a single expression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit deb443b8b7859ee204b26c9298796a84b5786324. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->