### PR TITLE
Move Quick Start above the fold, fix IRM ascii art

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,49 @@
 
 > **Alpha software.** APIs and import paths may change between releases.
 
+## Quick Start
+
+### Rust CLI
+
+```bash
+cargo install --path crates/services/hush-cli
+
+clawdstrike check --action-type file --ruleset strict ~/.ssh/id_rsa
+# → DENIED: forbidden_path guard matched pattern "**/.ssh/**"
+```
+
+### TypeScript
+
+```bash
+npm install @clawdstrike/sdk
+```
+
+```typescript
+import { Clawdstrike } from "@clawdstrike/sdk";
+
+const cs = Clawdstrike.withDefaults("strict");
+const decision = await cs.checkNetwork("api.openai.com:443");
+console.log(decision.status); // "denied" - strict blocks all egress by default
+```
+
+### Python
+
+```bash
+pip install clawdstrike
+```
+
+```python
+from clawdstrike import Policy, PolicyEngine, GuardAction, GuardContext
+
+engine = PolicyEngine(Policy.from_yaml_file("policy.yaml"))
+ctx = GuardContext(cwd="/app", session_id="session-123")
+
+allowed = engine.is_allowed(GuardAction.file_access("/home/user/.ssh/id_rsa"), ctx)
+# → False
+```
+
+---
+
 ## The Problem
 
 Google's 2026 Cybersecurity Forecast calls it the **"Shadow Agent" crisis**: employees and teams spinning up AI agents without corporate oversight, creating invisible pipelines that exfiltrate sensitive data, violate compliance, and leak IP. No one sanctioned them. No one is watching them. And your security stack wasn't built for this.
@@ -195,10 +238,10 @@ Runtime interceptors between sandboxed modules and host calls. Every intercepted
 
 ```
 Sandboxed Module
-       │
+            │
 IRM Router ─┬─ Filesystem Monitor
-             ├─ Network Monitor
-             └─ Execution Monitor
+            ├─ Network Monitor
+            └─ Execution Monitor
 ```
 
 </td>
@@ -229,49 +272,6 @@ Ed25519-signed provenance markers embedded in prompts for attribution and forens
 </td>
 </tr>
 </table>
-
----
-
-## Quick Start
-
-### Rust CLI
-
-```bash
-cargo install --path crates/services/hush-cli
-
-clawdstrike check --action-type file --ruleset strict ~/.ssh/id_rsa
-# → DENIED: forbidden_path guard matched pattern "**/.ssh/**"
-```
-
-### TypeScript
-
-```bash
-npm install @clawdstrike/sdk
-```
-
-```typescript
-import { Clawdstrike } from "@clawdstrike/sdk";
-
-const cs = Clawdstrike.withDefaults("strict");
-const decision = await cs.checkNetwork("api.openai.com:443");
-console.log(decision.status); // "denied" - strict blocks all egress by default
-```
-
-### Python
-
-```bash
-pip install clawdstrike
-```
-
-```python
-from clawdstrike import Policy, PolicyEngine, GuardAction, GuardContext
-
-engine = PolicyEngine(Policy.from_yaml_file("policy.yaml"))
-ctx = GuardContext(cwd="/app", session_id="session-123")
-
-allowed = engine.is_allowed(GuardAction.file_access("/home/user/.ssh/id_rsa"), ctx)
-# → False
-```
 
 ---
 


### PR DESCRIPTION
## Summary
- Move **Quick Start** section (Rust CLI, TypeScript, Python) immediately after the alpha callout so users see install/usage before the narrative "Problem" and "What Clawdstrike Is" sections
- Fix IRM ascii art alignment — branch characters (`├─`, `└─`) now vertically align with `┬`

## Test plan
- [ ] Verify Quick Start renders correctly after the alpha callout on GitHub
- [ ] Verify IRM diagram box-drawing characters are vertically aligned in the grid cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that reorders README content and tweaks an ASCII diagram; no runtime or API behavior changes.
> 
> **Overview**
> Moves the `Quick Start` section (Rust CLI, TypeScript, Python install/usage snippets) to immediately follow the alpha callout so setup instructions appear before the longer narrative sections.
> 
> Fixes alignment in the `Inline Reference Monitors` ASCII diagram so the branch lines (`├─`/`└─`) vertically line up under the router junction (`┬`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068e66bfbde59cca35fcd53927fcb76b8de01806. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->