### PR TITLE
Move Quick Start above the fold, fix grid layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,8 @@ When agents spawn agents, who controls whom? Clawdstrike's multi-agent layer pro
 
 <table>
 <tr>
-<td width="50%">
-
-#### Inline Reference Monitors
+<td width="50%" valign="top">
+<h4 align="center">Inline Reference Monitors</h4>
 
 Runtime interceptors between sandboxed modules and host calls. Every intercepted call produces an `IrmEvent` with a decision for complete behavioral audit.
 
@@ -245,25 +244,22 @@ IRM Router ─┬─ Filesystem Monitor
 ```
 
 </td>
-<td width="50%">
-
-#### Output Sanitization
+<td width="50%" valign="top">
+<h4 align="center">Output Sanitization</h4>
 
 Catches secrets that make it into model output on the way out. Scans for API keys, tokens, PII, internal URLs, and custom patterns. Redaction strategies: full replacement, partial masking, type labels, stable SHA-256 hashing. Batch and streaming modes.
 
 </td>
 </tr>
 <tr>
-<td width="50%">
-
-#### Prompt Watermarking
+<td width="50%" valign="top">
+<h4 align="center">Prompt Watermarking</h4>
 
 Ed25519-signed provenance markers embedded in prompts for attribution and forensic tracing. Carries app ID, session ID, sequence number, and timestamp (RFC 8785). Survives model inference round-trips.
 
 </td>
-<td width="50%">
-
-#### Threat Intel & WASM Plugins
+<td width="50%" valign="top">
+<h4 align="center">Threat Intel & WASM Plugins</h4>
 
 **Threat feeds:** VirusTotal, Snyk, Google Safe Browsing — with circuit breakers, rate limiting, and caching. External failures never block the pipeline.
 


### PR DESCRIPTION
## Summary
- Move **Quick Start** section (Rust CLI, TypeScript, Python) immediately after the alpha callout so users see install/usage before the narrative sections
- Fix IRM ascii art alignment — branch characters (`├─`, `└─`) now vertically align with `┬`
- Center grid headers with `<h4 align="center">` and top-align cells with `valign="top"`

## Test plan
- [ ] Verify Quick Start renders correctly after the alpha callout on GitHub
- [ ] Verify IRM diagram box-drawing characters are vertically aligned
- [ ] Verify grid cell headers are centered and content top-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only changes that reorder content and adjust HTML/ASCII formatting; minimal risk beyond potential GitHub rendering/markdown layout regressions.
> 
> **Overview**
> Moves the `Quick Start` section (Rust CLI, TypeScript, Python) to immediately follow the alpha callout so installation/usage is visible earlier.
> 
> Polishes the capabilities grid in `README.md` by top-aligning table cells, centering section headers with `<h4 align="center">`, and fixing the IRM ASCII diagram alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af1d8963e240796ff0789e4f12af9ecba37c5d1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->