### PR TITLE
Jailbreak detection: side-by-side layout with technical detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,11 +188,13 @@ Composable, policy-driven security checks at the tool boundary. Each guard handl
 </td>
 <td width="50%" valign="top">
 
-**Session aggregation** tracks risk across an entire conversation with time-decaying rolling scores.
+**~15ms total latency.** All four layers run in sequence without external API calls (unless you opt into the LLM judge). The ML layer is a configurable linear model with sigmoid activation — weights live in your YAML policy, not a black box.
 
-An attacker who spreads a jailbreak across 20 innocuous-looking messages still triggers detection. Their cumulative risk score rises until it crosses the threshold.
+**9 attack taxonomies.** Role-play, authority confusion, encoding attacks, hypothetical framing, adversarial suffixes, system impersonation, instruction extraction, multi-turn grooming, and payload splitting.
 
-Persistent session state survives across connections via pluggable storage backends.
+**Session aggregation** tracks cumulative risk across an entire conversation with a time-decaying rolling score (15-minute half-life). An attacker who spreads a jailbreak across 20 innocuous messages still triggers detection — their score rises until it crosses the threshold.
+
+**Privacy-safe.** Raw input never appears in detection results. Only match spans and SHA-256 fingerprints are stored. Unicode NFKC normalization and zero-width character stripping happen before any pattern matching.
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- Place jailbreak infographic on the left (50%) with detailed technical copy on the right
- Real implementation details: ~15ms latency, 9 attack taxonomies, configurable linear model weights in YAML, 15-minute half-life decay function, SHA-256 fingerprinting, NFKC normalization

## Test plan
- [ ] Verify image + text render side-by-side on GitHub
- [ ] Verify text is readable and doesn't overflow on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts README layout and expands descriptive copy; no runtime or security logic is modified.
> 
> **Overview**
> Updates the README’s `JailbreakGuard` section to render the infographic alongside a new right-hand column of technical details (latency, attack taxonomies, session aggregation half-life, and privacy-preserving fingerprinting/normalization).
> 
> Replaces the prior single centered image + brief paragraph with a two-column table layout and expanded copy for improved GitHub readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ceaa629b1079d7fdbed06eeacce5c3d4acb94e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->