### PR TITLE
Add Attack Range link to jailbreak section

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Composable, policy-driven security checks at the tool boundary. Each guard handl
 
 **Privacy-safe.** Raw input never appears in detection results. Only match spans and SHA-256 fingerprints are stored. Unicode NFKC normalization and zero-width character stripping happen before any pattern matching.
 
+**[Try this out for yourself in our Attack Range!](https://backbay.io/attack-range)**
+
 </td>
 </tr>
 </table>


### PR DESCRIPTION
## Summary
- Add "Try this out for yourself in our Attack Range!" link to the bottom of the jailbreak detection panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding an external link; no runtime, security, or data-handling behavior is affected.
> 
> **Overview**
> Adds a call-to-action link to the Attack Range (https://backbay.io/attack-range) in `README.md` under the jailbreak detection section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83b0294e779297336ff0b2eed276dfebb6531d21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->