### PR TITLE
Add pill-row TOC to Core Capabilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ flowchart LR
 
 ## Core Capabilities
 
+<p align="center">
+  <a href="#guard-stack"><strong>Guard Stack</strong></a>
+  &nbsp;&middot;&nbsp;
+  <a href="#jailbreak-detection"><strong>Jailbreak Detection</strong></a>
+  &nbsp;&middot;&nbsp;
+  <a href="#cryptographic-receipts"><strong>Receipts</strong></a>
+  &nbsp;&middot;&nbsp;
+  <a href="#multi-agent-security-primitives"><strong>Multi-Agent</strong></a>
+  &nbsp;&middot;&nbsp;
+  <a href="#irm--output-sanitization--watermarking--threat-intel"><strong>IRM &middot; Sanitization &middot; Watermarking &middot; Threat Intel</strong></a>
+</p>
+
 ### Guard Stack
 
 Composable, policy-driven security checks at the tool boundary. Each guard handles a specific threat surface and returns a verdict with evidence. Fail-fast or aggregate, your call.
@@ -181,6 +193,7 @@ Composable, policy-driven security checks at the tool boundary. Each guard handl
 
 ---
 
+<a id="jailbreak-detection"></a>
 <table>
 <tr>
 <td width="50%">
@@ -231,6 +244,7 @@ When agents spawn agents, who controls whom? Clawdstrike's multi-agent layer pro
 
 ---
 
+<a id="irm--output-sanitization--watermarking--threat-intel"></a>
 <table>
 <tr>
 <td width="50%" valign="top">


### PR DESCRIPTION
## Summary
- Add centered linked pill-row navigation under "Core Capabilities": **Guard Stack** · **Jailbreak Detection** · **Receipts** · **Multi-Agent** · **IRM · Sanitization · Watermarking · Threat Intel**
- Add HTML anchor IDs for sections without markdown headings (jailbreak image panel, grid)
- Also includes Attack Range link from previous work

## Test plan
- [ ] Verify all 5 pill links jump to the correct section
- [ ] Verify pill row renders centered on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README navigation/anchors; no runtime or API behavior impacted.
> 
> **Overview**
> Adds a centered, linked “pill-row” table of contents under `Core Capabilities` to jump to Guard Stack, Jailbreak Detection, Receipts, Multi-Agent, and IRM/Sanitization/Watermarking/Threat Intel.
> 
> Introduces explicit HTML anchors for the jailbreak detection panel and the IRM grid sections (which aren’t markdown headings), and adds an `Attack Range` link in the jailbreak section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3071dad275a4a33f28e09bad616f5b2fc456a133. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->