### PR TITLE
Use kbd pill style for Core Capabilities TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,15 +164,11 @@ flowchart LR
 ## Core Capabilities
 
 <p align="center">
-  <a href="#guard-stack"><strong>Guard Stack</strong></a>
-  &nbsp;&middot;&nbsp;
-  <a href="#jailbreak-detection"><strong>Jailbreak Detection</strong></a>
-  &nbsp;&middot;&nbsp;
-  <a href="#cryptographic-receipts"><strong>Receipts</strong></a>
-  &nbsp;&middot;&nbsp;
-  <a href="#multi-agent-security-primitives"><strong>Multi-Agent</strong></a>
-  &nbsp;&middot;&nbsp;
-  <a href="#irm--output-sanitization--watermarking--threat-intel"><strong>IRM &middot; Sanitization &middot; Watermarking &middot; Threat Intel</strong></a>
+  <a href="#guard-stack"><kbd>Guard Stack</kbd></a>&nbsp;&nbsp;
+  <a href="#jailbreak-detection"><kbd>Jailbreak Detection</kbd></a>&nbsp;&nbsp;
+  <a href="#cryptographic-receipts"><kbd>Receipts</kbd></a>&nbsp;&nbsp;
+  <a href="#multi-agent-security-primitives"><kbd>Multi-Agent</kbd></a>&nbsp;&nbsp;
+  <a href="#irm--output-sanitization--watermarking--threat-intel"><kbd>IRM · Sanitization · Watermarking · Threat Intel</kbd></a>
 </p>
 
 ### Guard Stack


### PR DESCRIPTION
## Summary
- Switch TOC links from `<strong>` + middot separators to `<kbd>` tags for button-like pill styling, matching other Backbay READMEs

## Test plan
- [ ] Verify kbd pills render with bordered button appearance on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure README presentation change that only affects how the Core Capabilities TOC renders on GitHub, with no runtime or API impact.
> 
> **Overview**
> Updates the README’s **Core Capabilities** mini-TOC to use `<kbd>` “pill” links with simple spacing, replacing the prior `<strong>` styling and middot separators to match the styling used in related READMEs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef4c60ddce4812c3d26ff075182db495aaa4dc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->