### PR TITLE
feat: add Homebrew formula to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,15 +435,19 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact: hush-linux-x86_64
+            archive: clawdstrike-linux-x86_64
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact: hush-darwin-x86_64
+            archive: clawdstrike-darwin-x86_64
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: hush-darwin-aarch64
+            archive: clawdstrike-darwin-aarch64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             artifact: hush-windows-x86_64.exe
+            archive: ""
     steps:
       - uses: actions/checkout@v6
 
@@ -468,6 +472,22 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
+
+      - name: Create release archive (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p _archive
+          cp target/${{ matrix.target }}/release/hush _archive/
+          cp target/${{ matrix.target }}/release/clawdstrike _archive/
+          tar -czf ${{ matrix.archive }}.tar.gz -C _archive .
+
+      - name: Upload release archive
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.archive }}.tar.gz
+          path: ${{ matrix.archive }}.tar.gz
 
   build-hushd-binaries:
     name: Build hushd Binaries
@@ -626,3 +646,85 @@ jobs:
           overwrite_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-homebrew:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs: [resolve-version, create-release]
+    steps:
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-version.outputs.tag }}
+        run: |
+          mkdir -p dl
+          gh release download "$TAG" \
+            --repo backbay-labs/clawdstrike \
+            --pattern "clawdstrike-*.tar.gz" \
+            --dir dl
+
+      - name: Compute SHA256 checksums
+        id: sha
+        run: |
+          echo "darwin_arm64=$(sha256sum dl/clawdstrike-darwin-aarch64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "darwin_x86_64=$(sha256sum dl/clawdstrike-darwin-x86_64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "linux_x86_64=$(sha256sum dl/clawdstrike-linux-x86_64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Update homebrew-tap formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          SHA_DARWIN_ARM64: ${{ steps.sha.outputs.darwin_arm64 }}
+          SHA_DARWIN_X86_64: ${{ steps.sha.outputs.darwin_x86_64 }}
+          SHA_LINUX_X86_64: ${{ steps.sha.outputs.linux_x86_64 }}
+        run: |
+          set -euo pipefail
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/backbay-labs/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+
+          cat > tap/Formula/clawdstrike.rb << 'RUBY'
+          class Clawdstrike < Formula
+            desc "Runtime security enforcement for AI agents"
+            homepage "https://github.com/backbay-labs/clawdstrike"
+            version "__VERSION__"
+            license "Apache-2.0"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/backbay-labs/clawdstrike/releases/download/v#{version}/clawdstrike-darwin-aarch64.tar.gz"
+                sha256 "__SHA_DARWIN_ARM64__"
+              else
+                url "https://github.com/backbay-labs/clawdstrike/releases/download/v#{version}/clawdstrike-darwin-x86_64.tar.gz"
+                sha256 "__SHA_DARWIN_X86_64__"
+              end
+            end
+
+            on_linux do
+              url "https://github.com/backbay-labs/clawdstrike/releases/download/v#{version}/clawdstrike-linux-x86_64.tar.gz"
+              sha256 "__SHA_LINUX_X86_64__"
+            end
+
+            def install
+              bin.install "hush"
+              bin.install "clawdstrike"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/hush --version")
+            end
+          end
+          RUBY
+
+          sed -i "s/__VERSION__/${VERSION}/" tap/Formula/clawdstrike.rb
+          sed -i "s/__SHA_DARWIN_ARM64__/${SHA_DARWIN_ARM64}/" tap/Formula/clawdstrike.rb
+          sed -i "s/__SHA_DARWIN_X86_64__/${SHA_DARWIN_X86_64}/" tap/Formula/clawdstrike.rb
+          sed -i "s/__SHA_LINUX_X86_64__/${SHA_LINUX_X86_64}/" tap/Formula/clawdstrike.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/clawdstrike.rb
+          git diff --cached --quiet && echo "Formula unchanged; skipping" && exit 0
+          git commit -m "clawdstrike ${VERSION}"
+          git push

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@
 
 ## Quick Start
 
-### Rust CLI
+### CLI
 
 ```bash
-cargo install --path crates/services/hush-cli
+brew tap backbay-labs/tap
+brew install clawdstrike
 
 clawdstrike check --action-type file --ruleset strict ~/.ssh/id_rsa
 # → DENIED: forbidden_path guard matched pattern "**/.ssh/**"


### PR DESCRIPTION
## Summary
- Adds tar.gz archive creation to `build-binaries` job (packages both `hush` + `clawdstrike` binaries for macOS and Linux)
- Adds `update-homebrew` job that pushes `Formula/clawdstrike.rb` to `backbay-labs/homebrew-tap` after each release
- Updates README Quick Start to show `brew install` instead of `cargo install`

## Install command after merge + release
```bash
brew tap backbay-labs/tap
brew install clawdstrike
```

## Secret required
Uses existing `HOMEBREW_TAP_GITHUB_TOKEN` secret (already configured).

## Test plan
- [ ] Merge to main
- [ ] Re-trigger Release workflow for v0.1.2 (existing crate/npm/pypi publishes will be skipped as idempotent)
- [ ] Verify tar.gz archives appear in GitHub Release assets
- [ ] Verify `Formula/clawdstrike.rb` is pushed to homebrew-tap
- [ ] `brew tap backbay-labs/tap && brew install clawdstrike`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline to produce new `clawdstrike-*.tar.gz` assets and to automatically push a Homebrew formula to an external repo using `HOMEBREW_TAP_GITHUB_TOKEN`, which could break releases or publish incorrect checksums if misconfigured.
> 
> **Overview**
> The release workflow now builds and uploads Unix `clawdstrike-*.tar.gz` archives that bundle both `hush` and `clawdstrike` binaries (in addition to existing per-binary artifacts).
> 
> After a GitHub Release is created, a new `update-homebrew` job downloads those archives, computes SHA256s, generates `Formula/clawdstrike.rb`, and pushes updates to `backbay-labs/homebrew-tap`.
> 
> The README Quick Start switches CLI installation instructions from `cargo install` to `brew tap`/`brew install clawdstrike`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f3ca15d6454b87a254b64c002a5ddfbb08e3058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->