### PR TITLE
fix: remove deprecation warning from clawdstrike binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/backbay-labs/clawdstrike"

--- a/crates/libs/hush-wasm/package.json
+++ b/crates/libs/hush-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/wasm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "WebAssembly bindings for clawdstrike cryptographic verification",
   "main": "hush_wasm.js",
   "types": "hush_wasm.d.ts",

--- a/crates/services/hush-cli/src/clawdstrike.rs
+++ b/crates/services/hush-cli/src/clawdstrike.rs
@@ -2,8 +2,6 @@ use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
 
 fn main() {
-    eprintln!("clawdstrike is deprecated; use `hush` instead.");
-
     let mut args = std::env::args_os();
     // Skip argv[0]
     let _ = args.next();

--- a/infra/packaging/HomebrewFormula/hush.rb
+++ b/infra/packaging/HomebrewFormula/hush.rb
@@ -9,7 +9,7 @@
 class Hush < Formula
   desc "CLI for clawdstrike security verification and policy enforcement"
   homepage "https://github.com/backbay-labs/clawdstrike"
-  url "https://github.com/backbay-labs/clawdstrike/archive/refs/tags/v0.1.2.tar.gz"
+  url "https://github.com/backbay-labs/clawdstrike/archive/refs/tags/v0.1.3.tar.gz"
   sha256 "PLACEHOLDER_SHA256_WILL_BE_UPDATED_ON_RELEASE"
   license "Apache-2.0"
   head "https://github.com/backbay-labs/clawdstrike.git", branch: "main"

--- a/packages/adapters/clawdstrike-adapter-core/package.json
+++ b/packages/adapters/clawdstrike-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/adapter-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Framework-agnostic adapter interfaces for Clawdstrike",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-claude/package.json
+++ b/packages/adapters/clawdstrike-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/claude",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "In-process tool boundary hooks for Claude Code and the Claude Agent SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-hush-cli-engine/package.json
+++ b/packages/adapters/clawdstrike-hush-cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/engine-local",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Policy engine adapter that shells out to hush policy eval",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-hushd-engine/package.json
+++ b/packages/adapters/clawdstrike-hushd-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/engine-remote",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Policy engine adapter that calls hushd /api/v1/eval",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-langchain/package.json
+++ b/packages/adapters/clawdstrike-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/langchain",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Minimal Clawdstrike tool wrappers for LangChain tools",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-openai/package.json
+++ b/packages/adapters/clawdstrike-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/openai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "In-process tool boundary hooks for the OpenAI Agents SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-openclaw/package.json
+++ b/packages/adapters/clawdstrike-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/openclaw",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Clawdstrike security plugin for OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-opencode/package.json
+++ b/packages/adapters/clawdstrike-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/opencode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "In-process tool boundary hooks for OpenCode-style coding assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-vercel-ai/package.json
+++ b/packages/adapters/clawdstrike-vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/vercel-ai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Minimal Clawdstrike tool wrappers for the Vercel AI SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy/clawdstrike-policy/package.json
+++ b/packages/policy/clawdstrike-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/policy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Canonical policy loader and engine (async guards + threat intel)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/clawdstrike/package.json
+++ b/packages/sdk/clawdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdstrike",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Official Clawdstrike TypeScript SDK",
   "type": "module",
   "main": "./index.cjs",

--- a/packages/sdk/hush-py/pyproject.toml
+++ b/packages/sdk/hush-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawdstrike"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python SDK for clawdstrike security verification"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk/hush-py/src/clawdstrike/__init__.py
+++ b/packages/sdk/hush-py/src/clawdstrike/__init__.py
@@ -58,7 +58,7 @@ from clawdstrike.canonical import canonicalize, canonical_hash
 from clawdstrike.native import NATIVE_AVAILABLE
 from clawdstrike.certification_badge import verify_certification_badge
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     "__version__",

--- a/packages/sdk/hush-ts/package.json
+++ b/packages/sdk/hush-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for clawdstrike security verification",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Remove erroneous "clawdstrike is deprecated" warning from the `clawdstrike` binary — it's the product name, not a deprecated alias
- Bump version to 0.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a misleading stderr warning and bumps package/formula versions; no security- or data-path logic changes.
> 
> **Overview**
> Removes the misleading "clawdstrike is deprecated" warning from the `clawdstrike` shim binary so it cleanly forwards args to `hush` without extra stderr output.
> 
> Bumps the release version from `0.1.2` to `0.1.3` across the Rust workspace, JS/WASM packages, Python SDK (`__version__`/`pyproject.toml`), and the Homebrew formula URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d8c728e042e4a29db7a855bcb7961a82294726d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->