### PR TITLE
docs(readme): expand CLI quick start examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,23 @@
 brew tap backbay-labs/tap
 brew install clawdstrike
 
+# Block access to sensitive paths
 clawdstrike check --action-type file --ruleset strict ~/.ssh/id_rsa
-# → DENIED: forbidden_path guard matched pattern "**/.ssh/**"
+# → BLOCKED [Critical]: Access to forbidden path: ~/.ssh/id_rsa
+
+# Control network egress
+clawdstrike check --action-type egress --ruleset strict api.openai.com:443
+# → BLOCKED [Error]: Egress to api.openai.com blocked by policy
+
+# Restrict MCP tool invocations
+clawdstrike check --action-type mcp --ruleset strict shell_exec
+# → BLOCKED [Error]: Tool 'shell_exec' is blocked by policy
+
+# Show available rulesets
+clawdstrike policy list
+
+# Diff two policies
+clawdstrike policy diff strict default
 ```
 
 ### TypeScript


### PR DESCRIPTION
## Summary
- Add egress, MCP tool, policy list, and policy diff examples to the CLI quick start section
- Use actual output from the CLI (e.g. `BLOCKED [Critical]:` instead of `DENIED:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds/edits README examples without affecting runtime behavior.
> 
> **Overview**
> Updates `README.md` CLI quick start to show more realistic, end-to-end policy usage: blocking sensitive file access, controlling egress, and restricting MCP tool invocations.
> 
> Adds examples for `clawdstrike policy list` and `clawdstrike policy diff`, and refreshes the sample `check` output to use the current `BLOCKED [Severity]: ...` format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d355fb31e2904297de789c1d8352149c73970a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->