### PR TITLE
docs(readme): add OpenClaw plugin quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,43 @@ allowed = engine.is_allowed(GuardAction.file_access("/home/user/.ssh/id_rsa"), c
 # → False
 ```
 
+### OpenClaw Plugin
+
+Clawdstrike ships as a first-class [OpenClaw](https://openclaw.com) plugin that enforces policy at the tool boundary — every tool call your agent makes is checked against your policy before execution.
+
+```bash
+openclaw plugins install @clawdstrike/openclaw
+openclaw plugins enable clawdstrike-security
+```
+
+Configure the plugin in your project's `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "clawdstrike-security": {
+      "policy": "clawdstrike:ai-agent",
+      "mode": "deterministic",
+      "guards": {
+        "forbidden_path": true,
+        "egress": true,
+        "secret_leak": true,
+        "patch_integrity": true
+      }
+    }
+  }
+}
+```
+
+The plugin hooks into the agent lifecycle automatically — preflight checks block dangerous operations before execution, post-execution guards redact secrets from tool output, and the audit logger records every decision. Set `mode` to `"advisory"` to warn without blocking, or `"audit"` to log only.
+
+Agents can also self-check permissions at runtime via the auto-registered `policy_check` tool:
+
+```
+policy_check({ action: "file_write", resource: "~/.ssh/authorized_keys" })
+# → { status: "deny", guard: "forbidden_path", reason: "matches **/.ssh/**" }
+```
+
 ---
 
 ## The Problem


### PR DESCRIPTION
## Summary
- Add OpenClaw plugin section to Quick Start (after TypeScript/Python)
- Covers install, `openclaw.json` config, enforcement modes (`deterministic`/`advisory`/`audit`), and the agent-facing `policy_check` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or policy enforcement logic is modified.
> 
> **Overview**
> Adds an **OpenClaw plugin** section to the README Quick Start, documenting how to install/enable `@clawdstrike/openclaw`, configure `openclaw.json` (policy ref, `mode`, and guard toggles), and use the agent-facing `policy_check` tool for runtime permission checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5324e037bfd33acab15b45793bee016d7143925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->