### PR TITLE
docs(readme): trim OpenClaw section, link to guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,33 +127,7 @@ openclaw plugins install @clawdstrike/openclaw
 openclaw plugins enable clawdstrike-security
 ```
 
-Configure the plugin in your project's `openclaw.json`:
-
-```json
-{
-  "plugins": {
-    "clawdstrike-security": {
-      "policy": "clawdstrike:ai-agent",
-      "mode": "deterministic",
-      "guards": {
-        "forbidden_path": true,
-        "egress": true,
-        "secret_leak": true,
-        "patch_integrity": true
-      }
-    }
-  }
-}
-```
-
-The plugin hooks into the agent lifecycle automatically — preflight checks block dangerous operations before execution, post-execution guards redact secrets from tool output, and the audit logger records every decision. Set `mode` to `"advisory"` to warn without blocking, or `"audit"` to log only.
-
-Agents can also self-check permissions at runtime via the auto-registered `policy_check` tool:
-
-```
-policy_check({ action: "file_write", resource: "~/.ssh/authorized_keys" })
-# → { status: "deny", guard: "forbidden_path", reason: "matches **/.ssh/**" }
-```
+[Configure the plugin](docs/src/guides/openclaw-integration.md#configuration) in your project's `openclaw.json`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove inline JSON config and extra paragraphs from OpenClaw quick start
- Replace with a single sentence linking to the [integration guide's Configuration section](docs/src/guides/openclaw-integration.md#configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it removes duplicated setup details and relies on the external guide link being correct and stable.
> 
> **Overview**
> Simplifies the README’s **OpenClaw Plugin** quick start by removing the embedded `openclaw.json` configuration example and the extended explanatory text (including the `policy_check` snippet).
> 
> Replaces that content with a single link directing readers to the OpenClaw integration guide’s `#configuration` section for setup details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acc48b72e5d7722d0dbc5c83b7be10ab37c82e99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->