### PR TITLE
docs(readme): add SDK & bindings see-also to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ openclaw plugins enable clawdstrike-security
 
 [Configure the plugin](docs/src/guides/openclaw-integration.md#configuration) in your project's `openclaw.json`.
 
+### Additional SDKs & Bindings
+
+Framework adapters: [OpenAI](packages/adapters/clawdstrike-openai/README.md) · [Claude](packages/adapters/clawdstrike-claude/README.md) · [Vercel AI](docs/src/guides/vercel-ai-integration.md) · [LangChain](docs/src/guides/langchain-integration.md)
+
+[C, Go, C#](docs/src/concepts/multi-language.md) via FFI · [WebAssembly](crates/libs/hush-wasm/README.md)
+
 ---
 
 ## The Problem


### PR DESCRIPTION
## Summary
- Add compact "Additional SDKs & Bindings" section between OpenClaw plugin and "The Problem"
- Links to framework adapters (OpenAI, Claude, Vercel AI, LangChain), FFI bindings (C, Go, C#), and WebAssembly
- All link targets verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it adds cross-links in `README.md` without altering any runtime code or behavior.
> 
> **Overview**
> Adds a new **“Additional SDKs & Bindings”** section to the `README.md` Quick Start, linking out to framework adapters (OpenAI, Claude, Vercel AI, LangChain), multi-language FFI bindings (C/Go/C#), and the WebAssembly package docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33d9d6ec23d005e8c388f9ca28d7f1a330c2367d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->