### PR TITLE
docs(readme): add Jailbreak Detection header

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Composable, policy-driven security checks at the tool boundary. Each guard handl
 
 ---
 
+<h3 align="center">Jailbreak Detection</h3>
+
 <a id="jailbreak-detection"></a>
 <table>
 <tr>


### PR DESCRIPTION
## Summary
- Add centered "Jailbreak Detection" heading above the jailbreak section, between the guards table and the detail layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a section heading; no code or behavior changes.
> 
> **Overview**
> Adds a centered `Jailbreak Detection` header in `README.md` between the guard stack table and the jailbreak detection section content to improve readability and section separation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6029c1c738c27a1bd1ba79ea17bb9898b6b228bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->