### PR TITLE
docs(readme): add npm and PyPI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 <p align="center">
   <a href="https://github.com/backbay-labs/clawdstrike/actions"><img src="https://img.shields.io/github/actions/workflow/status/backbay-labs/clawdstrike/ci.yml?branch=main&style=flat-square&logo=github&label=CI" alt="CI Status"></a>
   <a href="https://crates.io/crates/clawdstrike"><img src="https://img.shields.io/crates/v/clawdstrike?style=flat-square&logo=rust" alt="crates.io"></a>
+  <a href="https://www.npmjs.com/package/@clawdstrike/sdk"><img src="https://img.shields.io/npm/v/@clawdstrike/sdk?style=flat-square&logo=npm&label=npm" alt="npm"></a>
+  <a href="https://pypi.org/project/clawdstrike/"><img src="https://img.shields.io/pypi/v/clawdstrike?style=flat-square&logo=python&logoColor=white&label=PyPI" alt="PyPI"></a>
   <a href="https://docs.rs/clawdstrike"><img src="https://img.shields.io/docsrs/clawdstrike?style=flat-square&logo=docs.rs" alt="docs.rs"></a>
   <a href="https://artifacthub.io/packages/search?repo=clawdstrike"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/clawdstrike" alt="Artifact Hub"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License: Apache-2.0"></a>


### PR DESCRIPTION
## Summary
- Add `@clawdstrike/sdk` npm badge (links to npmjs.com)
- Add `clawdstrike` PyPI badge (links to pypi.org)
- Inserted between crates.io and docs.rs in the existing badge row

Badge order: CI → crates.io → **npm** → **PyPI** → docs.rs → Artifact Hub → License → MSRV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds external npm/PyPI version badges to the README; no runtime or build behavior is affected.
> 
> **Overview**
> Adds **npm** and **PyPI** version badges to `README.md`, linking to `@clawdstrike/sdk` on npmjs.com and `clawdstrike` on pypi.org, positioned alongside the existing status/package badges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ab56558076d46f071f9f104eece9d05881ee529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->