### PR TITLE
docs(readme): add Homebrew, downloads, and Discord badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
   <a href="https://www.npmjs.com/package/@clawdstrike/sdk"><img src="https://img.shields.io/npm/v/@clawdstrike/sdk?style=flat-square&logo=npm&label=npm" alt="npm"></a>
   <a href="https://pypi.org/project/clawdstrike/"><img src="https://img.shields.io/pypi/v/clawdstrike?style=flat-square&logo=python&logoColor=white&label=PyPI" alt="PyPI"></a>
   <a href="https://docs.rs/clawdstrike"><img src="https://img.shields.io/docsrs/clawdstrike?style=flat-square&logo=docs.rs" alt="docs.rs"></a>
+  <a href="https://github.com/backbay-labs/homebrew-tap/blob/main/Formula/clawdstrike.rb"><img src="https://img.shields.io/badge/homebrew-clawdstrike-FBB040?style=flat-square&logo=homebrew" alt="Homebrew"></a>
+  <a href="https://crates.io/crates/clawdstrike"><img src="https://img.shields.io/crates/d/clawdstrike?style=flat-square&logo=rust&label=downloads" alt="crates.io downloads"></a>
   <a href="https://artifacthub.io/packages/search?repo=clawdstrike"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/clawdstrike" alt="Artifact Hub"></a>
+  <a href="https://discord.gg/clawdstrike"><img src="https://img.shields.io/badge/discord-join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License: Apache-2.0"></a>
   <img src="https://img.shields.io/badge/MSRV-1.93-orange?style=flat-square&logo=rust" alt="MSRV: 1.93">
 </p>


### PR DESCRIPTION
## Summary
- **Homebrew** badge → links to `homebrew-tap/Formula/clawdstrike.rb`
- **Downloads** badge → crates.io download count
- **Discord** badge → placeholder (`discord.gg/clawdstrike`), update the invite link once the server is live

Badge order: CI → crates.io → npm → PyPI → docs.rs → **Homebrew** → **Downloads** → Artifact Hub → **Discord** → License → MSRV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change; updates README badge links/images without affecting runtime behavior.
> 
> **Overview**
> Updates `README.md` to add three new top-of-file badges: **Homebrew** (links to the tap formula), **crates.io downloads** (download count badge), and **Discord** (invite link badge).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fec41a3a990ee304ac8d2374cb1fb948a028837. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->