### PR TITLE
docs(readme): fix Enterprise Architecture Mermaid parse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,14 +717,22 @@ flowchart TB
     API <--> DB
     API <--> PROV
 
-    A1 & A2 & AN -->|HTTPS enrollment| API
-    API -->|NATS creds + subject prefix| A1 & A2 & AN
+    A1 -->|HTTPS enrollment| API
+    A2 -->|HTTPS enrollment| API
+    AN -->|HTTPS enrollment| API
+    API -->|NATS creds + subject prefix| A1
+    API -->|NATS creds + subject prefix| A2
+    API -->|NATS creds + subject prefix| AN
 
     API -->|policy publish/update| KV
-    KV -->|policy sync (KV watch)| A1 & A2 & AN
+    KV -->|policy sync (KV watch)| A1
+    KV -->|policy sync (KV watch)| A2
+    KV -->|policy sync (KV watch)| AN
 
     API -->|set_posture / reload / kill| CMD
-    CMD -->|request/reply ack| A1 & A2 & AN
+    CMD -->|request/reply ack| A1
+    CMD -->|request/reply ack| A2
+    CMD -->|request/reply ack| AN
 ```
 
 ### 2. Telemetry Plane


### PR DESCRIPTION
## Summary
- fix GitHub Mermaid parse error in Enterprise Architecture Control Plane diagram
- replace unsupported multi-target edge syntax (`A1 & A2 & AN`) with explicit per-node edges

## Why
GitHub Mermaid renderer fails on labeled fanout edges using `&`, which breaks README rendering.

## Validation
- verified README diagram block syntax is now explicit one-edge-per-node
- expected to render on GitHub Mermaid parser without parse errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts Mermaid syntax; no runtime code paths are affected.
> 
> **Overview**
> Fixes the Enterprise Architecture *Control Plane* Mermaid diagram in `README.md` to render on GitHub by replacing unsupported multi-target edge syntax (`A1 & A2 & AN`) with explicit per-agent edges for enrollment, credential delivery, policy sync, and command ack flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a8f61ff6717c9df03ac8ed14dde3e18a987536. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->