### PR TITLE
docs(readme): harden Mermaid syntax for Control Plane diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,26 +713,26 @@ flowchart TB
         PROV[External NATS Provisioner]
     end
 
-    DASH <--> API
-    API <--> DB
-    API <--> PROV
+    DASH <--> API;
+    API <--> DB;
+    API <--> PROV;
 
-    A1 -->|HTTPS enrollment| API
-    A2 -->|HTTPS enrollment| API
-    AN -->|HTTPS enrollment| API
-    API -->|NATS creds + subject prefix| A1
-    API -->|NATS creds + subject prefix| A2
-    API -->|NATS creds + subject prefix| AN
+    A1 -->|https enrollment| API;
+    A2 -->|https enrollment| API;
+    AN -->|https enrollment| API;
+    API -->|nats creds + subject prefix| A1;
+    API -->|nats creds + subject prefix| A2;
+    API -->|nats creds + subject prefix| AN;
 
-    API -->|policy publish/update| KV
-    KV -->|policy sync (KV watch)| A1
-    KV -->|policy sync (KV watch)| A2
-    KV -->|policy sync (KV watch)| AN
+    API -->|policy publish update| KV;
+    KV -->|policy sync kv watch| A1;
+    KV -->|policy sync kv watch| A2;
+    KV -->|policy sync kv watch| AN;
 
-    API -->|set_posture / reload / kill| CMD
-    CMD -->|request/reply ack| A1
-    CMD -->|request/reply ack| A2
-    CMD -->|request/reply ack| AN
+    API -->|set posture reload kill| CMD;
+    CMD -->|request reply ack| A1;
+    CMD -->|request reply ack| A2;
+    CMD -->|request reply ack| AN;
 ```
 
 ### 2. Telemetry Plane


### PR DESCRIPTION
## Summary
- harden Mermaid control-plane diagram syntax in README for GitHub renderer compatibility
- add explicit statement terminators (`;`) on control-plane edges
- simplify edge labels to plain text tokens (no parentheses/slashes)

## Why
GitHub was still reporting a Mermaid parse error in the Control Plane block after the first fix.
This follow-up uses conservative Mermaid syntax that is known to be accepted by GitHub's parser.

## Validation
- verified README block contains explicit per-edge statements and semicolon terminators
- labels in the previously failing lines are now plain text (`policy sync kv watch`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adjusts Mermaid diagram syntax/labels for GitHub rendering compatibility, with no code or behavior impact.
> 
> **Overview**
> Updates the README’s *Enterprise Architecture → Control Plane* Mermaid diagram to use more conservative syntax for GitHub’s renderer: adds explicit `;` terminators on edge statements and simplifies edge labels to plain text tokens (removing punctuation like slashes/parentheses).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0bdac1f65df667d3bd7f4f540bbbd83dd056c4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->