### PR TITLE
docs(readme): polish Control Plane architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,22 +695,35 @@ For organizations managing agent fleets across teams and environments, Clawdstri
 
 ```mermaid
 flowchart TB
-    AF[Agent Fleet]
-    API[Control API]
-    DASH[Control Console]
-    DB[(PostgreSQL)]
-    PROV[External NATS Provisioner]
-    KV[(Policy KV)]
-    CMD[(Command Subjects)]
+    subgraph ops ["Operator Surface"]
+        DASH[Control Console]
+    end
 
-    DASH <--> API
-    API <--> DB
-    API <--> PROV
-    AF <--> API
-    API --> KV
-    KV --> AF
-    API --> CMD
-    CMD --> AF
+    subgraph control ["Control Services"]
+        API[Control API]
+        DB[(PostgreSQL)]
+        PROV[External NATS Provisioner]
+    end
+
+    subgraph nats ["NATS Control Plane"]
+        KV[(Policy KV)]
+        CMD[(Command Subjects)]
+    end
+
+    subgraph fleet ["Managed Endpoints"]
+        AF[Agent Fleet]
+    end
+
+    DASH <-->|admin operations| API
+    API <-->|state and enrollment records| DB
+    API <-->|subject and credential provisioning| PROV
+
+    AF -.->|HTTPS enrollment request| API
+    API -.->|NATS credentials and subject prefix| AF
+    API -->|policy publish| KV
+    KV -->|KV watch sync| AF
+    API -->|command publish| CMD
+    CMD -->|request and reply acks| AF
 ```
 
 - Enrollment runs over HTTPS (`Agent Fleet <-> Control API`), and the API returns NATS credentials + subject prefix.


### PR DESCRIPTION
## Summary\n- polish the Enterprise Architecture Control Plane Mermaid diagram for readability and presentation\n- organize nodes into clear layers (operator surface, control services, NATS control plane, managed endpoints)\n- add explicit flow labels for enrollment, policy sync, and command delivery\n\n## Validation\n- manual README mermaid syntax review in rendered GitHub preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it only restructures the Mermaid Control Plane diagram and adds labeled flows with no code or behavioral impact.
> 
> **Overview**
> Updates the README’s *Enterprise Architecture → Control Plane* Mermaid diagram to improve readability by grouping components into labeled subgraphs (operator surface, control services, NATS control plane, managed endpoints).
> 
> Adds explicit, labeled edges for enrollment, policy sync, and command delivery to make the control-plane data flows clearer in the rendered documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31a2c3c70a3c628208f39a4f98a1cc6e5cc63bbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->