### PR TITLE
fix(ci): publish missing images, fix local dev compose

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -206,3 +206,126 @@ jobs:
           format: 'table'
           severity: 'HIGH,CRITICAL'
           exit-code: '1'
+
+  auditd-bridge:
+    name: Auditd Bridge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PUSH_TOKEN != '' && secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.auditd-bridge
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/auditd-bridge:latest
+            ${{ env.IMAGE_PREFIX }}/auditd-bridge:${{ github.sha }}
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && format('{0}/auditd-bridge:{1}', env.IMAGE_PREFIX, github.event.inputs.release_tag) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_PREFIX }}/auditd-bridge:${{ github.sha }}
+          format: 'table'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+
+  k8s-audit-bridge:
+    name: K8s Audit Bridge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PUSH_TOKEN != '' && secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.k8s-audit-bridge
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/k8s-audit-bridge:latest
+            ${{ env.IMAGE_PREFIX }}/k8s-audit-bridge:${{ github.sha }}
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && format('{0}/k8s-audit-bridge:{1}', env.IMAGE_PREFIX, github.event.inputs.release_tag) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_PREFIX }}/k8s-audit-bridge:${{ github.sha }}
+          format: 'table'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+
+  eas-anchor:
+    name: EAS Anchor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PUSH_TOKEN != '' && secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.eas-anchor
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/eas-anchor:latest
+            ${{ env.IMAGE_PREFIX }}/eas-anchor:${{ github.sha }}
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' && format('{0}/eas-anchor:{1}', env.IMAGE_PREFIX, github.event.inputs.release_tag) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_PREFIX }}/eas-anchor:${{ github.sha }}
+          format: 'table'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'

--- a/infra/docker/docker-compose.services.yaml
+++ b/infra/docker/docker-compose.services.yaml
@@ -19,11 +19,11 @@ services:
     ports:
       - "4222:4222"   # client
       - "8222:8222"   # monitoring
-    command: ["--jetstream", "--store_dir", "/data"]
+    command: ["--jetstream", "--store_dir", "/data", "-m", "8222"]
     volumes:
       - nats-data:/data
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]
+      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost:8222/healthz"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -37,11 +37,13 @@ services:
       dockerfile: infra/docker/Dockerfile.spine
       args:
         BIN: spine-checkpointer
+    command: ["--replicas", "1"]
     depends_on:
       nats:
         condition: service_healthy
     environment:
       NATS_URL: nats://nats:4222
+      SPINE_LOG_SEED_HEX: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
       RUST_LOG: info,spine=debug
 
   spine-witness:
@@ -55,6 +57,7 @@ services:
         condition: service_healthy
     environment:
       NATS_URL: nats://nats:4222
+      SPINE_WITNESS_SEED_HEX: "f1e1d1c1b1a191817161514131211101f0e0d0c0b0a090807060504030201000"
       RUST_LOG: info,spine=debug
 
   spine-proofs-api:

--- a/scripts/update-all-on-profile-tags.sh
+++ b/scripts/update-all-on-profile-tags.sh
@@ -13,6 +13,9 @@ Updates all-on profile image tags to the provided SHA:
   - hushd.image.tag -> <sha>
   - bridges.tetragon.image.tag -> <sha>
   - bridges.hubble.image.tag -> <sha>
+  - bridges.auditd.image.tag -> <sha>
+  - bridges.k8sAudit.image.tag -> <sha>
+  - easAnchor.image.tag -> <sha>
 EOF
 }
 
@@ -73,6 +76,9 @@ updated = {
     "hushd": False,
     "tetragon": False,
     "hubble": False,
+    "auditd": False,
+    "k8sAudit": False,
+    "easAnchor": False,
 }
 
 for idx, line in enumerate(lines):
@@ -103,6 +109,15 @@ for idx, line in enumerate(lines):
     elif section == "bridges" and bridge == "hubble" and indent == 6:
         lines[idx] = re.sub(r'tag:\s*".*"', f'tag: "{sha}"', line)
         updated["hubble"] = True
+    elif section == "bridges" and bridge == "auditd" and indent == 6:
+        lines[idx] = re.sub(r'tag:\s*".*"', f'tag: "{sha}"', line)
+        updated["auditd"] = True
+    elif section == "bridges" and bridge == "k8sAudit" and indent == 6:
+        lines[idx] = re.sub(r'tag:\s*".*"', f'tag: "{sha}"', line)
+        updated["k8sAudit"] = True
+    elif section == "easAnchor" and indent == 4:
+        lines[idx] = re.sub(r'tag:\s*".*"', f'tag: "{sha}"', line)
+        updated["easAnchor"] = True
 
 missing = [k for k, v in updated.items() if not v]
 if missing:


### PR DESCRIPTION
## Summary
- Add CI jobs for `auditd-bridge`, `k8s-audit-bridge`, `eas-anchor` to `docker.yml` — fixes `ImagePullBackOff` on EKS
- Update profile tag promotion script to cover all 7 images (was only 4)
- Fix `docker-compose.services.yaml` for out-of-the-box local dev: enable NATS monitoring (`-m 8222`), fix healthcheck, set `--replicas 1` for single-node NATS, add required seed env vars

## Test plan
- [x] YAML validation: all 7 jobs present with correct Dockerfiles
- [x] Tag promotion script: idempotent, updates all 7 tags
- [x] Local compose: `docker compose up` brings all 4 services to healthy
- [x] Darwin telemetry bridge: connects to NATS, publishes events, 0 failures
- [x] Spine: checkpoints created, Merkle roots verified, proofs API healthy
- [x] Policy engine: all guards (forbidden_path, shell_command, egress, secret_leak) working
- [x] Audit logging: all events recorded with correct decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD and local-dev configuration changes only; primary risk is misconfigured tags/build paths causing missing images or broken compose startup.
> 
> **Overview**
> Publishes additional container images by extending `.github/workflows/docker.yml` with build/push/scan jobs for `auditd-bridge`, `k8s-audit-bridge`, and `eas-anchor`, tagging them as `latest`, `${{ github.sha }}`, and optional `release_tag`.
> 
> Improves local dev reliability in `infra/docker/docker-compose.services.yaml` by enabling NATS monitoring, fixing the NATS healthcheck invocation, and setting single-replica + required seed env vars for Spine services.
> 
> Extends `scripts/update-all-on-profile-tags.sh` to also update Helm profile tags for the new bridge images and `easAnchor`, failing fast if any expected tag is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bd0fe1dd2df1e61ffa52d412bc2d741db4b0fef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->