### PR TITLE
fix(clippy): suppress expect_used in test module and too_many_arguments

### DIFF
--- a/apps/agent/src-tauri/src/policy.rs
+++ b/apps/agent/src-tauri/src/policy.rs
@@ -73,6 +73,7 @@ fn normalize_policy_check_input(mut input: PolicyCheckInput) -> PolicyCheckInput
     input
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn enqueue_offline_audit_event(
     audit_queue: Option<&Arc<crate::daemon::AuditQueue>>,
     action_type: &str,

--- a/crates/libs/clawdstrike-policy-event/src/decision.rs
+++ b/crates/libs/clawdstrike-policy-event/src/decision.rs
@@ -22,6 +22,7 @@ pub(crate) fn severity_from_value(value: &serde_json::Value) -> Option<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use serde_json::json;


### PR DESCRIPTION
## Summary
- Allow `clippy::expect_used` in `clawdstrike-policy-event` test module where `json!()` output is statically known
- Allow `clippy::too_many_arguments` on `enqueue_offline_audit_event` in agent

Fixes the release CI clippy gate for v0.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ad7874095329fb61bce1cdf14a7e385c905fbca0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->