### PR TITLE
fix(clippy): unblock main CI after 0.2.4 merge

### DIFF
--- a/crates/libs/clawdstrike/src/async_guards/threat_intel/spider_sense.rs
+++ b/crates/libs/clawdstrike/src/async_guards/threat_intel/spider_sense.rs
@@ -352,8 +352,10 @@ impl SpiderSensePolicyConfig {
         // - allow explicit programmatic toggle-only enable overrides
         //   (`enabled=true` with all other fields at programmatic defaults)
         let explicit_programmatic_enable_toggle = child.enabled && !self.enabled && {
-            let mut toggle_only = Self::default();
-            toggle_only.enabled = true;
+            let toggle_only = Self {
+                enabled: true,
+                ..Self::default()
+            };
             child == &toggle_only
         };
 
@@ -2017,9 +2019,11 @@ mod tests {
         base.similarity_threshold = 0.91;
         base.top_k = 7;
 
-        let mut child = SpiderSensePolicyConfig::default();
-        child.enabled = true;
-        child.top_k = 11;
+        let child = SpiderSensePolicyConfig {
+            enabled: true,
+            top_k: 11,
+            ..SpiderSensePolicyConfig::default()
+        };
 
         let merged = base.merge_with(&child);
         assert!(merged.enabled);
@@ -2038,8 +2042,10 @@ mod tests {
     fn spider_sense_policy_merge_with_present_fields_allows_explicit_enable_override() {
         let mut base = test_cfg();
         base.enabled = false;
-        let mut child = SpiderSensePolicyConfig::default();
-        child.enabled = true;
+        let child = SpiderSensePolicyConfig {
+            enabled: true,
+            ..SpiderSensePolicyConfig::default()
+        };
         let present_fields = std::iter::once("enabled".to_string()).collect();
 
         let merged = base.merge_with_present_fields(&child, &present_fields);
@@ -2053,8 +2059,7 @@ mod tests {
     fn spider_sense_policy_merge_with_allows_programmatic_disable_override() {
         let mut base = test_cfg();
         base.enabled = true;
-        let mut child = SpiderSensePolicyConfig::default();
-        child.enabled = false;
+        let child = SpiderSensePolicyConfig::default();
 
         let merged = base.merge_with(&child);
         assert!(!merged.enabled, "child enabled=false should override base");
@@ -2064,8 +2069,10 @@ mod tests {
     fn spider_sense_policy_merge_with_allows_programmatic_enable_toggle_override() {
         let mut base = test_cfg();
         base.enabled = false;
-        let mut child = SpiderSensePolicyConfig::default();
-        child.enabled = true;
+        let child = SpiderSensePolicyConfig {
+            enabled: true,
+            ..SpiderSensePolicyConfig::default()
+        };
 
         let merged = base.merge_with(&child);
         assert!(
@@ -2079,9 +2086,11 @@ mod tests {
         let mut base = test_cfg();
         base.enabled = false;
         base.similarity_threshold = 0.84;
-        let mut child = SpiderSensePolicyConfig::default();
-        child.enabled = true;
-        child.similarity_threshold = 0.91;
+        let child = SpiderSensePolicyConfig {
+            enabled: true,
+            similarity_threshold: 0.91,
+            ..SpiderSensePolicyConfig::default()
+        };
 
         let merged = base.merge_with(&child);
         assert!(
@@ -2141,9 +2150,11 @@ mod tests {
         let mut base = test_cfg();
         base.enabled = false;
         base.similarity_threshold = 0.84;
-        let mut child = SpiderSensePolicyConfig::default();
-        child.enabled = true;
-        child.similarity_threshold = 0.91;
+        let child = SpiderSensePolicyConfig {
+            enabled: true,
+            similarity_threshold: 0.91,
+            ..SpiderSensePolicyConfig::default()
+        };
         let present_fields = std::iter::once("enabled".to_string())
             .chain(std::iter::once("similarity_threshold".to_string()))
             .collect();

--- a/crates/libs/clawdstrike/src/policy.rs
+++ b/crates/libs/clawdstrike/src/policy.rs
@@ -581,7 +581,7 @@ impl Policy {
         {
             let mut policy = policy;
             policy.guards.spider_sense_present_fields = spider_sense_present_fields_from_yaml(yaml);
-            return Ok(policy);
+            Ok(policy)
         }
         #[cfg(not(feature = "full"))]
         {


### PR DESCRIPTION
## Summary\n- fix  violations in Spider-Sense merge tests\n- fix  in policy YAML parsing path\n\n## Why\nMain CI is currently failing on strict clippy () after merging release prep.\n\n## Validation\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors for lint compliance; no functional logic changes beyond equivalent initialization/return style.
> 
> **Overview**
> Removes clippy-triggering patterns by switching Spider-Sense merge logic and related unit tests from `let mut ...; field = ...` to struct update initialization (`Self { ..Self::default() }`).
> 
> Cleans up `Policy::from_yaml_unvalidated` under the `full` feature by dropping an explicit `return Ok(policy)` in favor of a direct `Ok(policy)`, keeping behavior unchanged while unblocking strict CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d37141457c6def049bea54cfadd7d38fad881f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->