### PR TITLE
chore: release 0.2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -626,8 +626,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} -p hush-cli
+      - name: Build release binaries
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p hush-cli
+          cargo build --release --target ${{ matrix.target }} -p hushd
 
       - name: Rename binary (Unix)
         if: runner.os != 'Windows'
@@ -650,6 +652,7 @@ jobs:
           mkdir -p _archive
           cp target/${{ matrix.target }}/release/hush _archive/
           cp target/${{ matrix.target }}/release/clawdstrike _archive/
+          cp target/${{ matrix.target }}/release/hushd _archive/
           tar -czf ${{ matrix.archive }}.tar.gz -C _archive .
 
       - name: Upload release archive
@@ -906,10 +909,12 @@ jobs:
             def install
               bin.install "hush"
               bin.install "clawdstrike"
+              bin.install "hushd"
             end
 
             test do
               assert_match version.to_s, shell_output("#{bin}/hush --version")
+              assert_match "hushd", shell_output("#{bin}/hushd --version")
             end
           end
           RUBY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "auditd-bridge"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-runtime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-nats",
  "axum",
@@ -1662,7 +1662,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clawdstrike"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "clawdstrike-control-api"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-nats",
  "axum",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "clawdstrike-guard-sdk"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clawdstrike-guard-sdk-macros",
  "serde",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "clawdstrike-guard-sdk-macros"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "clawdstrike-ocsf"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "proptest",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "clawdstrike-policy-event"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "clawdstrike-registry"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-telemetry-bridge"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -2588,7 +2588,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "eas-anchor"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3486,7 +3486,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hubble-bridge"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "hunt-correlate"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-nats",
  "chrono",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "hunt-query"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-nats",
  "chrono",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "hunt-scan"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "clawdstrike",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "hush-certification"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "hush-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "hush-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "criterion",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "hush-ffi"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.22.1",
  "clawdstrike",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "hush-multi-agent"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "hush-core",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "hush-native"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.22.1",
  "clawdstrike",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "hush-proxy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "globset",
  "proptest",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "hush-spine"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "hush-wasm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clawdstrike",
  "clawdstrike-policy-event",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "hushd"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "k8s-audit-bridge"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "sdr-integration-tests"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-nats",
  "futures",
@@ -6821,7 +6821,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spine-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "tetragon-bridge"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/backbay-labs/clawdstrike"
@@ -151,17 +151,17 @@ md-5 = "0.10"
 jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 
 # Internal crates
-hush-core = { path = "crates/libs/hush-core", version = "0.2.4" }
-hush-proxy = { path = "crates/libs/hush-proxy", version = "0.2.4" }
-clawdstrike = { path = "crates/libs/clawdstrike", version = "0.2.4", default-features = false }
-hush-certification = { path = "crates/libs/hush-certification", version = "0.2.4" }
-spine = { package = "hush-spine", path = "crates/libs/spine", version = "0.2.4" }
-bridge-runtime = { path = "crates/libs/bridge-runtime", version = "0.2.4" }
-hunt-scan = { path = "crates/libs/hunt-scan", version = "0.2.4" }
-hunt-query = { path = "crates/libs/hunt-query", version = "0.2.4" }
-hunt-correlate = { path = "crates/libs/hunt-correlate", version = "0.2.4" }
-clawdstrike-ocsf = { path = "crates/libs/clawdstrike-ocsf", version = "0.2.4" }
-clawdstrike-policy-event = { path = "crates/libs/clawdstrike-policy-event", version = "0.2.4", default-features = false }
+hush-core = { path = "crates/libs/hush-core", version = "0.2.5" }
+hush-proxy = { path = "crates/libs/hush-proxy", version = "0.2.5" }
+clawdstrike = { path = "crates/libs/clawdstrike", version = "0.2.5", default-features = false }
+hush-certification = { path = "crates/libs/hush-certification", version = "0.2.5" }
+spine = { package = "hush-spine", path = "crates/libs/spine", version = "0.2.5" }
+bridge-runtime = { path = "crates/libs/bridge-runtime", version = "0.2.5" }
+hunt-scan = { path = "crates/libs/hunt-scan", version = "0.2.5" }
+hunt-query = { path = "crates/libs/hunt-query", version = "0.2.5" }
+hunt-correlate = { path = "crates/libs/hunt-correlate", version = "0.2.5" }
+clawdstrike-ocsf = { path = "crates/libs/clawdstrike-ocsf", version = "0.2.5" }
+clawdstrike-policy-event = { path = "crates/libs/clawdstrike-policy-event", version = "0.2.5", default-features = false }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ flowchart LR
     H -.-> I[Control API + Control Console]
 ```
 
+Three layers, one system:
+
+| Layer | What It Does |
+| ----- | ------------ |
+| **Guard Stack** | 13 composable guards at the tool boundary: path access, egress, secrets, shell commands, MCP tools, jailbreak detection, prompt injection, CUA controls, Spider-Sense threat screening. Every verdict is Ed25519-signed into a non-repudiable receipt. |
+| **Swarm C2** | An operational control plane for managing agent fleets in production. Durable, replayable fleet transport over NATS JetStream, policy flow coordination via Spine, enrollment and credential provisioning, posture commands with request/reply acknowledgements, and a Proofs API + Control Console for verification and SOC workflows. |
+| **Swarm Trace** | Prevention + hunting at the agent tool boundary. Hunt across signed receipts, kernel telemetry (Tetragon, auditd), and network flows (Hubble), build timelines, run natural-language and structured queries, correlate against detection rules, and ship OCSF-formatted findings straight into your SIEM. |
+
 ---
 
 ## Why This Matters

--- a/apps/agent/src-tauri/Cargo.toml
+++ b/apps/agent/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clawdstrike-agent"
-version = "0.2.4"
+version = "0.2.5"
 description = "Clawdstrike Agent - Security enforcement runtime for AI coding tools"
 edition = "2021"
 rust-version = "1.80"

--- a/apps/agent/src-tauri/tauri.conf.json
+++ b/apps/agent/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clawdstrike Agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "dev.clawdstrike.agent",
   "build": {
     "beforeDevCommand": "sh scripts/prepare-bundled-hushd.sh dev",

--- a/crates/libs/hush-wasm/package.json
+++ b/crates/libs/hush-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/wasm",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "WebAssembly bindings for clawdstrike cryptographic verification",
   "main": "hush_wasm.js",
   "types": "hush_wasm.d.ts",

--- a/infra/docker/workspace-hushd.toml
+++ b/infra/docker/workspace-hushd.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/backbay-labs/clawdstrike"
@@ -110,15 +110,15 @@ pubgrub = "0.3"
 jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 
 # Internal crates
-hush-core = { path = "crates/libs/hush-core", version = "0.2.4" }
-hush-proxy = { path = "crates/libs/hush-proxy", version = "0.2.4" }
-spine = { package = "hush-spine", path = "crates/libs/spine", version = "0.2.4" }
-clawdstrike = { path = "crates/libs/clawdstrike", version = "0.2.4" }
-clawdstrike-ocsf = { path = "crates/libs/clawdstrike-ocsf", version = "0.2.4" }
-clawdstrike-policy-event = { path = "crates/libs/clawdstrike-policy-event", version = "0.2.4", default-features = false }
-hunt-scan = { path = "crates/libs/hunt-scan", version = "0.2.4" }
-hunt-query = { path = "crates/libs/hunt-query", version = "0.2.4" }
-hush-certification = { path = "crates/libs/hush-certification", version = "0.2.4" }
+hush-core = { path = "crates/libs/hush-core", version = "0.2.5" }
+hush-proxy = { path = "crates/libs/hush-proxy", version = "0.2.5" }
+spine = { package = "hush-spine", path = "crates/libs/spine", version = "0.2.5" }
+clawdstrike = { path = "crates/libs/clawdstrike", version = "0.2.5" }
+clawdstrike-ocsf = { path = "crates/libs/clawdstrike-ocsf", version = "0.2.5" }
+clawdstrike-policy-event = { path = "crates/libs/clawdstrike-policy-event", version = "0.2.5", default-features = false }
+hunt-scan = { path = "crates/libs/hunt-scan", version = "0.2.5" }
+hunt-query = { path = "crates/libs/hunt-query", version = "0.2.5" }
+hush-certification = { path = "crates/libs/hush-certification", version = "0.2.5" }
 
 [profile.release]
 lto = true

--- a/infra/docker/workspace-registry.toml
+++ b/infra/docker/workspace-registry.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/backbay-labs/clawdstrike"
@@ -118,10 +118,10 @@ md-5 = "0.10"
 jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 
 # Internal crates
-hush-core = { path = "crates/libs/hush-core", version = "0.2.4" }
-clawdstrike = { path = "crates/libs/clawdstrike", version = "0.2.4", default-features = false }
-spine = { package = "hush-spine", path = "crates/libs/spine", version = "0.2.4" }
-hush-proxy = { path = "crates/libs/hush-proxy", version = "0.2.4" }
+hush-core = { path = "crates/libs/hush-core", version = "0.2.5" }
+clawdstrike = { path = "crates/libs/clawdstrike", version = "0.2.5", default-features = false }
+spine = { package = "hush-spine", path = "crates/libs/spine", version = "0.2.5" }
+hush-proxy = { path = "crates/libs/hush-proxy", version = "0.2.5" }
 
 [profile.release]
 lto = true

--- a/infra/packaging/HomebrewFormula/hush.rb
+++ b/infra/packaging/HomebrewFormula/hush.rb
@@ -9,7 +9,7 @@
 class Hush < Formula
   desc "CLI for clawdstrike security verification and policy enforcement"
   homepage "https://github.com/backbay-labs/clawdstrike"
-  url "https://github.com/backbay-labs/clawdstrike/archive/refs/tags/v0.2.4.tar.gz"
+  url "https://github.com/backbay-labs/clawdstrike/archive/refs/tags/v0.2.5.tar.gz"
   sha256 "PLACEHOLDER_SHA256_WILL_BE_UPDATED_ON_RELEASE"
   license "Apache-2.0"
   head "https://github.com/backbay-labs/clawdstrike.git", branch: "main"
@@ -18,24 +18,15 @@ class Hush < Formula
 
   def install
     system "cargo", "install", *std_cargo_args(path: "crates/services/hush-cli")
+    system "cargo", "install", *std_cargo_args(path: "crates/services/hushd")
 
     # Generate shell completions
     generate_completions_from_executable(bin/"hush", "completions")
   end
 
-  def caveats
-    <<~EOS
-      This formula installs the `hush` CLI only.
-
-      The `hushd` daemon is experimental and is not installed by default.
-      If you want to try it anyway, build it from source:
-
-        cargo install --path crates/services/hushd
-    EOS
-  end
-
   test do
     assert_match "hush #{version}", shell_output("#{bin}/hush --version")
+    assert_match "hushd", shell_output("#{bin}/hushd --version")
 
     # Test basic help
     assert_match "security verification", shell_output("#{bin}/hush --help")

--- a/packages/adapters/clawdstrike-adapter-core/package.json
+++ b/packages/adapters/clawdstrike-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/adapter-core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Framework-agnostic adapter interfaces for Clawdstrike",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-claude/package.json
+++ b/packages/adapters/clawdstrike-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/claude",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "In-process tool boundary hooks for Claude Code and the Claude Agent SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-engine-adaptive/package.json
+++ b/packages/adapters/clawdstrike-engine-adaptive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/engine-adaptive",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Adaptive policy engine with automatic mode switching between local and remote engines",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-hush-cli-engine/package.json
+++ b/packages/adapters/clawdstrike-hush-cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/engine-local",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Policy engine adapter that shells out to hush policy eval",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-hushd-engine/package.json
+++ b/packages/adapters/clawdstrike-hushd-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/engine-remote",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Policy engine adapter that calls hushd /api/v1/eval",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-langchain/package.json
+++ b/packages/adapters/clawdstrike-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/langchain",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Minimal Clawdstrike tool wrappers for LangChain tools",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-openai/package.json
+++ b/packages/adapters/clawdstrike-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/openai",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "In-process tool boundary hooks for the OpenAI Agents SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-openclaw/package.json
+++ b/packages/adapters/clawdstrike-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/openclaw",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Clawdstrike security plugin for OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-opencode/package.json
+++ b/packages/adapters/clawdstrike-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/opencode",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "In-process tool boundary hooks for OpenCode-style coding assistants",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/clawdstrike-vercel-ai/package.json
+++ b/packages/adapters/clawdstrike-vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/vercel-ai",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Minimal Clawdstrike tool wrappers for the Vercel AI SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy/clawdstrike-policy/package.json
+++ b/packages/policy/clawdstrike-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/policy",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Canonical policy loader and engine (async guards + threat intel)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/clawdstrike-hunt/package.json
+++ b/packages/sdk/clawdstrike-hunt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/hunt",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Hunt query, timeline, and local file loading for Clawdstrike",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/clawdstrike/package.json
+++ b/packages/sdk/clawdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdstrike",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Official Clawdstrike TypeScript SDK",
   "type": "module",
   "main": "./index.cjs",

--- a/packages/sdk/hush-py/hush-native/Cargo.toml
+++ b/packages/sdk/hush-py/hush-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush-native"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "Bundled native Rust extension for clawdstrike Python SDK"
 license = "Apache-2.0"

--- a/packages/sdk/hush-py/hush-native/pyproject.toml
+++ b/packages/sdk/hush-py/hush-native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "clawdstrike"
-version = "0.2.4"
+version = "0.2.5"
 description = "Python SDK for clawdstrike security verification"
 readme = "../README.md"
 requires-python = ">=3.10"

--- a/packages/sdk/hush-py/pyproject.toml
+++ b/packages/sdk/hush-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawdstrike"
-version = "0.2.4"
+version = "0.2.5"
 description = "Python SDK for clawdstrike security verification"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/sdk/hush-py/src/clawdstrike/__init__.py
+++ b/packages/sdk/hush-py/src/clawdstrike/__init__.py
@@ -87,7 +87,7 @@ from clawdstrike.receipt import (
 )
 from clawdstrike.types import Decision, DecisionStatus, SessionOptions, SessionSummary
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 __all__ = [
     "__version__",

--- a/packages/sdk/hush-ts/package.json
+++ b/packages/sdk/hush-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clawdstrike/sdk",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "TypeScript SDK for clawdstrike security verification",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Bump all versions from 0.2.4 to 0.2.5 (Cargo, npm, PyPI, Tauri, Docker workspace manifests)
- Fix homebrew formula to include `hushd` in the release tarball and `bin.install`
- Release workflow `build-binaries` job now also builds `hushd` so it ships in `clawdstrike-*.tar.gz`
- Update README "What Clawdstrike Is" section with Swarm C2 and Swarm Trace layer descriptions

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] After merge + tag `v0.2.5`, verify release workflow includes `hushd` in tarball
- [ ] `brew upgrade clawdstrike` installs `hushd` and `clawdstrike daemon start` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version bump and release/packaging adjustments; minimal runtime behavior changes, with the main risk being release artifact contents and Homebrew install expectations.
> 
> **Overview**
> Bumps the project version from `0.2.4` to `0.2.5` across Cargo workspace/crates, npm packages, PyPI metadata, Tauri app config, and Docker workspace manifests.
> 
> Updates release/packaging to **ship `hushd` by default**: the GitHub release workflow now builds `hushd` in `build-binaries` and includes it in the Unix `clawdstrike-*.tar.gz` archives, and Homebrew formulas/install/tests are updated to install and verify `hushd`.
> 
> Refreshes README messaging by adding a "Three layers" overview table (Guard Stack / Swarm C2 / Swarm Trace).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a81da31ae195e9473079aca8535d299e3aec2dbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->