### PR TITLE
fix(cilium): remove L7 DNS proxy rules breaking namespace DNS

### DIFF
--- a/infra/deploy/cilium-policies/00-namespace-isolation.yaml
+++ b/infra/deploy/cilium-policies/00-namespace-isolation.yaml
@@ -39,6 +39,3 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
-          rules:
-            dns:
-              - matchPattern: "*"

--- a/infra/deploy/cilium-policies/08-allow-dns.yaml
+++ b/infra/deploy/cilium-policies/08-allow-dns.yaml
@@ -19,6 +19,3 @@ spec:
         - ports:
             - port: "53"
               protocol: ANY
-          rules:
-            dns:
-              - matchPattern: "*"


### PR DESCRIPTION
## Summary
- Remove `rules.dns` L7 proxy directives from `sdr-namespace-default-deny` and `sdr-allow-dns` CiliumNetworkPolicies
- Keep plain L3/L4 port 53 UDP/TCP allow for DNS resolution
- Spine-witness retains its scoped L7 DNS rules (required for `toFQDNs` AWS STS)

## Problem
The Cilium L7 DNS proxy was silently dropping DNS responses for all pods in the `clawdstrike` namespace. DNS queries were forwarded to CoreDNS but responses never returned, causing:
- `control-api` unable to resolve postgres hostname → fatal crash loop
- All new pods in the namespace unable to resolve any DNS

## Root Cause
The `rules.dns` block forces traffic through Cilium's L7 DNS proxy. The proxy was in a broken state (likely after a node event), and since it intercepts rather than passes through, responses were silently dropped. Removing L7 interception lets DNS flow at L3/L4 directly.

## Test plan
- [ ] Merge and let ArgoCD sync
- [ ] Verify DNS resolution works: `kubectl run -n clawdstrike dns-test --rm -i --restart=Never --image=busybox -- nslookup clawdstrike-helm-nats`
- [ ] Verify control-api reaches Ready 1/1
- [ ] Verify hushd still running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Kubernetes network policy enforcement for DNS, so a misconfiguration could impact name resolution/connectivity for the `clawdstrike` namespace. The change is small and narrows behavior (removes L7 inspection) which should be straightforward to validate.
> 
> **Overview**
> Removes the `rules.dns` L7 DNS-proxy section from the `sdr-namespace-default-deny` and `sdr-allow-dns` CiliumNetworkPolicies so DNS egress to CoreDNS is allowed purely via L3/L4 `port: 53` (protocol `ANY`).
> 
> This change stops forcing DNS through Cilium’s L7 proxy, reducing the chance of namespace-wide DNS failures caused by proxy interception.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0eb3dd5963c4aba8cecd415314fd49908ea692f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->