### PR TITLE
refactor(agent+hushd): extract clawdstrike-hushd-config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clawdstrike-hushd-config"
+version = "0.2.7"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
 name = "clawdstrike-logos"
 version = "0.2.7"
 dependencies = [
@@ -4035,6 +4044,7 @@ dependencies = [
  "clap",
  "clawdstrike",
  "clawdstrike-broker-protocol",
+ "clawdstrike-hushd-config",
  "clawdstrike-logos",
  "clawdstrike-ocsf",
  "clawdstrike-policy-event",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/libs/hunt-correlate",
     "crates/libs/clawdstrike-ocsf",
     "crates/libs/clawdstrike-policy-event",
+    "crates/libs/clawdstrike-hushd-config",
     "crates/libs/clawdstrike-logos",
     "crates/libs/logos-ffi",
     "crates/libs/hushspec",
@@ -180,6 +181,7 @@ logos-ffi = { path = "crates/libs/logos-ffi", version = "0.2.7" }
 logos-z3 = { path = "crates/libs/logos-z3", version = "0.2.7" }
 clawdstrike-ocsf = { path = "crates/libs/clawdstrike-ocsf", version = "0.2.7" }
 clawdstrike-policy-event = { path = "crates/libs/clawdstrike-policy-event", version = "0.2.7", default-features = false }
+clawdstrike-hushd-config = { path = "crates/libs/clawdstrike-hushd-config", version = "0.2.7" }
 nono = { path = "infra/vendor/nono", version = "0.11.0", default-features = false }
 
 [profile.release]

--- a/apps/agent/src-tauri/Cargo.lock
+++ b/apps/agent/src-tauri/Cargo.lock
@@ -156,6 +156,8 @@ dependencies = [
 [[package]]
 name = "async-nats"
 version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23419d455dc57d3ae60a2f4278cf561fc74fe866e548e14d2b0ad3e1b8ca0b2"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -171,7 +173,7 @@ dependencies = [
  "ring",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -697,6 +699,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "clawdstrike-hushd-config",
  "clawdstrike-policy-event",
  "dirs 5.0.1",
  "ed25519-dalek",
@@ -730,6 +733,14 @@ dependencies = [
  "uuid",
  "which",
  "zeroize",
+]
+
+[[package]]
+name = "clawdstrike-hushd-config"
+version = "0.2.7"
+dependencies = [
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -1025,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -3342,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
@@ -3430,7 +3441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4420,7 +4431,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -4483,7 +4494,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4495,6 +4506,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -5607,9 +5628,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
@@ -5746,9 +5767,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -6274,9 +6295,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -6678,7 +6699,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/agent/src-tauri/Cargo.toml
+++ b/apps/agent/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ which = "6"
 # Shared crypto/data primitives
 hush-core = { path = "../../../crates/libs/hush-core" }
 clawdstrike-policy-event = { path = "../../../crates/libs/clawdstrike-policy-event", default-features = false, features = ["simulate"] }
+clawdstrike-hushd-config = { path = "../../../crates/libs/clawdstrike-hushd-config" }
 base64 = "0.22"
 
 # NATS / Spine (adaptive SDR)

--- a/apps/agent/src-tauri/src/daemon.rs
+++ b/apps/agent/src-tauri/src/daemon.rs
@@ -3,6 +3,12 @@
 //! Handles spawning, monitoring, and restarting the hushd daemon.
 
 use anyhow::{Context, Result};
+use clawdstrike_hushd_config::{
+    DatadogExporterConfig, ElasticAuthConfig, ElasticExporterConfig, ExporterSettings,
+    ExportersConfig, GenericWebhookConfig, RuntimeConfig as HushdRuntimeConfig,
+    SiemConfig as HushdRuntimeSiemConfig, SpineConfig as HushdRuntimeSpineConfig,
+    SplunkExporterConfig, SumoLogicExporterConfig, WebhookAuthConfig, WebhookExporterConfig,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
@@ -76,129 +82,6 @@ pub struct DaemonConfig {
     pub policy_path: PathBuf,
     /// Canonical in-memory agent settings (preferred over on-disk reads).
     pub settings: Option<Arc<RwLock<crate::settings::Settings>>>,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeConfig {
-    listen: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    policy_path: Option<PathBuf>,
-    ruleset: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    signing_key: Option<PathBuf>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    siem: Option<HushdRuntimeSiemConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    spine: Option<HushdRuntimeSpineConfig>,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeSiemConfig {
-    enabled: bool,
-    exporters: HushdRuntimeExportersConfig,
-}
-
-#[derive(Debug, Default, Serialize)]
-struct HushdRuntimeExportersConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    splunk: Option<HushdRuntimeExporterSettings<HushdRuntimeSplunkConfig>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    elastic: Option<HushdRuntimeExporterSettings<HushdRuntimeElasticConfig>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    datadog: Option<HushdRuntimeExporterSettings<HushdRuntimeDatadogConfig>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    sumo_logic: Option<HushdRuntimeExporterSettings<HushdRuntimeSumoLogicConfig>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    webhooks: Option<HushdRuntimeExporterSettings<HushdRuntimeWebhookExporterConfig>>,
-}
-
-impl HushdRuntimeExportersConfig {
-    fn has_any(&self) -> bool {
-        self.splunk.is_some()
-            || self.elastic.is_some()
-            || self.datadog.is_some()
-            || self.sumo_logic.is_some()
-            || self.webhooks.is_some()
-    }
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeExporterSettings<T> {
-    enabled: bool,
-    #[serde(flatten)]
-    config: T,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeSplunkConfig {
-    hec_url: String,
-    hec_token: String,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeElasticConfig {
-    base_url: String,
-    index: String,
-    auth: HushdRuntimeElasticAuthConfig,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeElasticAuthConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    api_key: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeDatadogConfig {
-    api_key: String,
-    site: String,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeSumoLogicConfig {
-    http_source_url: String,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeWebhookExporterConfig {
-    webhooks: Vec<HushdRuntimeGenericWebhookConfig>,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeGenericWebhookConfig {
-    url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    method: Option<String>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    headers: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    auth: Option<HushdRuntimeWebhookAuthConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    content_type: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeWebhookAuthConfig {
-    #[serde(rename = "type")]
-    auth_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    token: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct HushdRuntimeSpineConfig {
-    enabled: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    nats_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    creds_file: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    token: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    nkey_seed: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    keypair_path: Option<PathBuf>,
-    subject_prefix: String,
 }
 
 impl DaemonConfig {
@@ -1717,7 +1600,7 @@ fn cleanup_runtime_enrollment_keypair(daemon_port: u16) -> Result<()> {
 fn build_runtime_siem_config(
     settings: &crate::settings::Settings,
 ) -> Option<HushdRuntimeSiemConfig> {
-    let mut exporters = HushdRuntimeExportersConfig::default();
+    let mut exporters = ExportersConfig::default();
 
     let siem = &settings.integrations.siem;
     let provider = siem.provider.trim().to_ascii_lowercase();
@@ -1729,9 +1612,9 @@ fn build_runtime_siem_config(
         match provider.as_str() {
             "datadog" => {
                 if !endpoint.is_empty() && !api_key.is_empty() {
-                    exporters.datadog = Some(HushdRuntimeExporterSettings {
+                    exporters.datadog = Some(ExporterSettings {
                         enabled: true,
-                        config: HushdRuntimeDatadogConfig {
+                        config: DatadogExporterConfig {
                             api_key: api_key.to_string(),
                             site: normalize_datadog_site(endpoint),
                         },
@@ -1744,9 +1627,9 @@ fn build_runtime_siem_config(
             }
             "splunk" => {
                 if !endpoint.is_empty() && !api_key.is_empty() {
-                    exporters.splunk = Some(HushdRuntimeExporterSettings {
+                    exporters.splunk = Some(ExporterSettings {
                         enabled: true,
-                        config: HushdRuntimeSplunkConfig {
+                        config: SplunkExporterConfig {
                             hec_url: endpoint.to_string(),
                             hec_token: api_key.to_string(),
                         },
@@ -1759,12 +1642,12 @@ fn build_runtime_siem_config(
             }
             "elastic" => {
                 if !endpoint.is_empty() && !api_key.is_empty() {
-                    exporters.elastic = Some(HushdRuntimeExporterSettings {
+                    exporters.elastic = Some(ExporterSettings {
                         enabled: true,
-                        config: HushdRuntimeElasticConfig {
+                        config: ElasticExporterConfig {
                             base_url: endpoint.to_string(),
                             index: "clawdstrike-security".to_string(),
-                            auth: HushdRuntimeElasticAuthConfig {
+                            auth: ElasticAuthConfig {
                                 api_key: Some(api_key.to_string()),
                             },
                         },
@@ -1777,9 +1660,9 @@ fn build_runtime_siem_config(
             }
             "sumo_logic" => {
                 if !endpoint.is_empty() {
-                    exporters.sumo_logic = Some(HushdRuntimeExporterSettings {
+                    exporters.sumo_logic = Some(ExporterSettings {
                         enabled: true,
-                        config: HushdRuntimeSumoLogicConfig {
+                        config: SumoLogicExporterConfig {
                             http_source_url: endpoint.to_string(),
                         },
                     });
@@ -1792,9 +1675,9 @@ fn build_runtime_siem_config(
             "custom" => {
                 if !endpoint.is_empty() {
                     let webhook = build_generic_webhook_exporter(endpoint, Some(api_key));
-                    exporters.webhooks = Some(HushdRuntimeExporterSettings {
+                    exporters.webhooks = Some(ExporterSettings {
                         enabled: true,
-                        config: HushdRuntimeWebhookExporterConfig {
+                        config: WebhookExporterConfig {
                             webhooks: vec![webhook],
                         },
                     });
@@ -1818,12 +1701,10 @@ fn build_runtime_siem_config(
     let webhook_secret = webhooks.secret.trim();
     let webhooks_requested = webhooks.enabled || !webhook_url.is_empty();
     if webhooks_requested && !webhook_url.is_empty() {
-        let exporter = exporters
-            .webhooks
-            .get_or_insert(HushdRuntimeExporterSettings {
-                enabled: true,
-                config: HushdRuntimeWebhookExporterConfig { webhooks: vec![] },
-            });
+        let exporter = exporters.webhooks.get_or_insert(ExporterSettings {
+            enabled: true,
+            config: WebhookExporterConfig { webhooks: vec![] },
+        });
 
         exporter
             .config
@@ -1868,21 +1749,18 @@ fn build_runtime_spine_config(
     })
 }
 
-fn build_generic_webhook_exporter(
-    url: &str,
-    token: Option<&str>,
-) -> HushdRuntimeGenericWebhookConfig {
+fn build_generic_webhook_exporter(url: &str, token: Option<&str>) -> GenericWebhookConfig {
     let token = token.map(str::trim).unwrap_or_default();
     let auth = if token.is_empty() {
         None
     } else {
-        Some(HushdRuntimeWebhookAuthConfig {
+        Some(WebhookAuthConfig {
             auth_type: "bearer".to_string(),
             token: Some(token.to_string()),
         })
     };
 
-    HushdRuntimeGenericWebhookConfig {
+    GenericWebhookConfig {
         url: url.to_string(),
         method: Some("POST".to_string()),
         headers: HashMap::new(),

--- a/crates/libs/clawdstrike-hushd-config/Cargo.toml
+++ b/crates/libs/clawdstrike-hushd-config/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "clawdstrike-hushd-config"
+description = "Shared on-disk runtime config DTOs for the hushd daemon (writer + reader source of truth)."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_yaml.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/libs/clawdstrike-hushd-config/src/lib.rs
+++ b/crates/libs/clawdstrike-hushd-config/src/lib.rs
@@ -1,0 +1,43 @@
+//! Shared on-disk DTOs for the hushd runtime configuration file.
+//!
+//! The desktop agent at `apps/agent/src-tauri/src/daemon.rs` writes a YAML
+//! runtime config that the `hushd` daemon at `crates/services/hushd/src/config.rs`
+//! must read. Historically the two sides defined their own private structs
+//! with the same field names. If they drifted (e.g. the writer added a field
+//! the reader didn't expect, or the reader added `#[serde(deny_unknown_fields)]`
+//! to a struct the writer omitted a key from), the result was a silent runtime
+//! failure: the agent would spawn `hushd` with a config it could not parse and
+//! the daemon would refuse to start.
+//!
+//! This crate is the single source of truth for that wire format. The DTOs
+//! here cover exactly the subset of `hushd`'s configuration schema that the
+//! desktop agent writes. Every field uses `#[serde(default)]` (or
+//! `skip_serializing_if`) so that the resulting YAML deserializes cleanly into
+//! either:
+//!
+//! * `clawdstrike_hushd_config::RuntimeConfig` (this crate's roundtrip target).
+//! * `hushd::config::Config` (the daemon's full reader, which is a strict
+//!   superset of the writer's schema).
+//!
+//! The crate is intentionally tiny: no async, no I/O, no implementation deps.
+//! It is shared between the desktop agent (excluded from the workspace) and
+//! `hushd` (a workspace member). Both sides should depend on this crate via
+//! path so that any future shape change must be expressed here once and is
+//! visible in both PRs.
+
+#![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub mod runtime;
+pub mod siem;
+pub mod spine;
+pub mod webhook;
+
+pub use runtime::RuntimeConfig;
+pub use siem::{
+    DatadogExporterConfig, ElasticAuthConfig, ElasticExporterConfig, ExporterSettings,
+    ExportersConfig, SiemConfig, SplunkExporterConfig, SumoLogicExporterConfig,
+    WebhookExporterConfig,
+};
+pub use spine::SpineConfig;
+pub use webhook::{GenericWebhookConfig, WebhookAuthConfig};

--- a/crates/libs/clawdstrike-hushd-config/src/runtime.rs
+++ b/crates/libs/clawdstrike-hushd-config/src/runtime.rs
@@ -1,0 +1,168 @@
+//! Top-level runtime config the desktop agent writes for `hushd`.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::siem::SiemConfig;
+use crate::spine::SpineConfig;
+
+/// Root configuration written to `hushd.runtime.<port>.yaml`.
+///
+/// The desktop agent emits this file as the canonical source of truth for the
+/// `hushd` daemon's runtime configuration. `hushd::config::Config` is a strict
+/// superset and will deserialise every field the writer emits while leaving
+/// daemon-only fields at their defaults.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    /// Listen address (e.g. `127.0.0.1:9876`).
+    pub listen: String,
+
+    /// Path to the policy YAML the daemon should load.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_path: Option<PathBuf>,
+
+    /// Ruleset name when `policy_path` is unset.
+    pub ruleset: String,
+
+    /// Path to the daemon's Ed25519 signing key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_key: Option<PathBuf>,
+
+    /// SIEM exporter configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub siem: Option<SiemConfig>,
+
+    /// Spine attestation log configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spine: Option<SpineConfig>,
+}
+
+impl RuntimeConfig {
+    /// Constructs a minimal runtime config used as the agent's starting
+    /// point. Callers populate optional integrations as needed.
+    #[must_use]
+    pub fn new(listen: impl Into<String>, ruleset: impl Into<String>) -> Self {
+        Self {
+            listen: listen.into(),
+            policy_path: None,
+            ruleset: ruleset.into(),
+            signing_key: None,
+            siem: None,
+            spine: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::siem::{
+        DatadogExporterConfig, ExporterSettings, ExportersConfig, SiemConfig, WebhookExporterConfig,
+    };
+    use crate::spine::SpineConfig;
+    use crate::webhook::{GenericWebhookConfig, WebhookAuthConfig};
+
+    fn sample_runtime_config() -> RuntimeConfig {
+        RuntimeConfig {
+            listen: "127.0.0.1:9876".to_string(),
+            policy_path: Some(PathBuf::from("/etc/clawdstrike/policy.yaml")),
+            ruleset: "default".to_string(),
+            signing_key: Some(PathBuf::from("/var/lib/clawdstrike/signing.key")),
+            siem: Some(SiemConfig {
+                enabled: true,
+                exporters: ExportersConfig {
+                    datadog: Some(ExporterSettings {
+                        enabled: true,
+                        config: DatadogExporterConfig {
+                            api_key: "abc123".to_string(),
+                            site: "datadoghq.com".to_string(),
+                        },
+                    }),
+                    webhooks: Some(ExporterSettings {
+                        enabled: true,
+                        config: WebhookExporterConfig {
+                            webhooks: vec![GenericWebhookConfig {
+                                url: "https://example.test/hook".to_string(),
+                                method: Some("POST".to_string()),
+                                headers: Default::default(),
+                                auth: Some(WebhookAuthConfig {
+                                    auth_type: "bearer".to_string(),
+                                    token: Some("secret".to_string()),
+                                }),
+                                content_type: Some("application/json".to_string()),
+                            }],
+                        },
+                    }),
+                    ..Default::default()
+                },
+            }),
+            spine: Some(SpineConfig {
+                enabled: true,
+                nats_url: Some("nats://127.0.0.1:4222".to_string()),
+                subject_prefix: "spine".to_string(),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn roundtrip_full_runtime_config() {
+        let original = sample_runtime_config();
+        let yaml = serde_yaml::to_string(&original).expect("serialise");
+        let decoded: RuntimeConfig = serde_yaml::from_str(&yaml).expect("deserialise");
+        let reencoded = serde_yaml::to_string(&decoded).expect("re-serialise");
+        assert_eq!(yaml, reencoded, "round-trip diverged: {yaml}");
+    }
+
+    #[test]
+    fn roundtrip_minimal_runtime_config() {
+        let original = RuntimeConfig::new("127.0.0.1:9876", "default");
+        let yaml = serde_yaml::to_string(&original).expect("serialise");
+        let decoded: RuntimeConfig = serde_yaml::from_str(&yaml).expect("deserialise");
+        let reencoded = serde_yaml::to_string(&decoded).expect("re-serialise");
+        assert_eq!(yaml, reencoded);
+    }
+
+    #[test]
+    fn minimal_runtime_config_yaml_omits_optionals() {
+        // Optional integrations should not appear in the on-disk YAML when
+        // they are `None`. This keeps the agent-written file compact and
+        // matches the pre-extraction behaviour.
+        let yaml = serde_yaml::to_string(&RuntimeConfig::new("127.0.0.1:9876", "default")).unwrap();
+        assert!(
+            !yaml.contains("siem:"),
+            "minimal YAML must not contain siem: {yaml}"
+        );
+        assert!(
+            !yaml.contains("spine:"),
+            "minimal YAML must not contain spine: {yaml}"
+        );
+        assert!(!yaml.contains("policy_path:"));
+        assert!(!yaml.contains("signing_key:"));
+        assert!(yaml.contains("listen: 127.0.0.1:9876"));
+        assert!(yaml.contains("ruleset: default"));
+    }
+
+    #[test]
+    fn accepts_legacy_yaml_with_unknown_keys() {
+        // hushd may add fields the writer does not know about (e.g. tls,
+        // audit, broker). We must still deserialise those YAML files into
+        // a `RuntimeConfig` while ignoring the unknown keys, so config files
+        // produced by newer hushd versions remain forwards-compatible.
+        let yaml = r#"
+listen: "127.0.0.1:9876"
+ruleset: "strict"
+tls: { cert_path: "/tmp/cert.pem", key_path: "/tmp/key.pem" }
+audit:
+  enabled: true
+broker:
+  enabled: false
+"#;
+        let cfg: RuntimeConfig = serde_yaml::from_str(yaml).expect("forwards-compatible parse");
+        assert_eq!(cfg.listen, "127.0.0.1:9876");
+        assert_eq!(cfg.ruleset, "strict");
+        assert!(cfg.siem.is_none());
+        assert!(cfg.spine.is_none());
+    }
+}

--- a/crates/libs/clawdstrike-hushd-config/src/siem.rs
+++ b/crates/libs/clawdstrike-hushd-config/src/siem.rs
@@ -1,0 +1,117 @@
+//! SIEM exporter DTOs written by the agent.
+//!
+//! Each exporter struct represents the subset of fields the desktop agent
+//! populates when materialising a runtime config from user-facing
+//! `IntegrationSettings`. `hushd`'s full reader (`SiemSoarConfig`,
+//! `SplunkConfig`, etc.) accepts additional fields with defaults; this crate
+//! intentionally only carries the keys the agent emits.
+//!
+//! ## Forwards-compatibility
+//!
+//! None of the structs use `#[serde(deny_unknown_fields)]`. Two reasons:
+//!
+//! 1. Existing on-disk configs may contain hushd-only fields (e.g. Datadog
+//!    `app_key`, Splunk `index`) that an old agent did not know about.
+//!    Deserialising those should not fail.
+//! 2. Future hushd versions may add fields the agent does not yet populate.
+//!    Round-tripping such configs through the agent should preserve the
+//!    daemon's data — currently we do this by only writing keys we know
+//!    about.
+
+use serde::{Deserialize, Serialize};
+
+use crate::webhook::GenericWebhookConfig;
+
+/// Top-level SIEM/SOAR block in the runtime YAML.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct SiemConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default)]
+    pub exporters: ExportersConfig,
+}
+
+/// Per-provider exporter wrappers.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ExportersConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub splunk: Option<ExporterSettings<SplunkExporterConfig>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elastic: Option<ExporterSettings<ElasticExporterConfig>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub datadog: Option<ExporterSettings<DatadogExporterConfig>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sumo_logic: Option<ExporterSettings<SumoLogicExporterConfig>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub webhooks: Option<ExporterSettings<WebhookExporterConfig>>,
+}
+
+impl ExportersConfig {
+    /// Returns `true` if at least one exporter is configured.
+    #[must_use]
+    pub fn has_any(&self) -> bool {
+        self.splunk.is_some()
+            || self.elastic.is_some()
+            || self.datadog.is_some()
+            || self.sumo_logic.is_some()
+            || self.webhooks.is_some()
+    }
+}
+
+/// Wrapper that mirrors hushd's `ExporterSettings<T>` enabled-flag layout.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExporterSettings<T> {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(flatten)]
+    pub config: T,
+}
+
+/// Splunk HEC exporter config.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct SplunkExporterConfig {
+    pub hec_url: String,
+    pub hec_token: String,
+}
+
+/// Elasticsearch exporter config.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ElasticExporterConfig {
+    pub base_url: String,
+    pub index: String,
+    #[serde(default)]
+    pub auth: ElasticAuthConfig,
+}
+
+/// Elasticsearch credential block.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ElasticAuthConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+}
+
+/// Datadog exporter config.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DatadogExporterConfig {
+    pub api_key: String,
+    pub site: String,
+}
+
+/// Sumo Logic exporter config.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct SumoLogicExporterConfig {
+    pub http_source_url: String,
+}
+
+/// Generic webhook exporter config (one or more destinations).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct WebhookExporterConfig {
+    #[serde(default)]
+    pub webhooks: Vec<GenericWebhookConfig>,
+}

--- a/crates/libs/clawdstrike-hushd-config/src/spine.rs
+++ b/crates/libs/clawdstrike-hushd-config/src/spine.rs
@@ -1,0 +1,62 @@
+//! Spine attestation log (NATS JetStream) configuration.
+//!
+//! Mirrors `hushd::config::SpineConfig`. Both the desktop agent's writer
+//! and the daemon's reader pull this type from `clawdstrike-hushd-config`.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Spine attestation log configuration written by the agent and read by hushd.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SpineConfig {
+    /// Whether to publish eval receipts to Spine (NATS JetStream).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// NATS server URL (e.g. `nats://127.0.0.1:4222`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nats_url: Option<String>,
+
+    /// Path to a `.creds` file for NATS authentication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub creds_file: Option<String>,
+
+    /// Bearer token for NATS authentication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+
+    /// NKey seed for NATS authentication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nkey_seed: Option<String>,
+
+    /// Path to an Ed25519 keypair used to sign Spine envelopes.
+    ///
+    /// `PathBuf` matches the desktop agent's representation; YAML
+    /// serialisation is identical to `Option<String>` so backwards-compatible
+    /// with older on-disk configs that stored the key as a plain string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keypair_path: Option<PathBuf>,
+
+    /// Subject prefix for NATS subjects.
+    #[serde(default = "default_subject_prefix")]
+    pub subject_prefix: String,
+}
+
+fn default_subject_prefix() -> String {
+    "spine".to_string()
+}
+
+impl Default for SpineConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            nats_url: None,
+            creds_file: None,
+            token: None,
+            nkey_seed: None,
+            keypair_path: None,
+            subject_prefix: default_subject_prefix(),
+        }
+    }
+}

--- a/crates/libs/clawdstrike-hushd-config/src/webhook.rs
+++ b/crates/libs/clawdstrike-hushd-config/src/webhook.rs
@@ -1,0 +1,48 @@
+//! Generic webhook DTOs used by SIEM exporter configurations.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A single generic HTTP webhook destination.
+///
+/// Mirrors the subset of `hushd::siem::exporters::webhooks::GenericWebhookConfig`
+/// the desktop agent populates. Optional fields use `skip_serializing_if` so
+/// the on-disk YAML stays compact and forward-compatible with future hushd
+/// fields.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct GenericWebhookConfig {
+    /// Destination URL.
+    pub url: String,
+
+    /// HTTP method (defaults to `POST` if unset).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+
+    /// Static headers to attach to every request.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headers: HashMap<String, String>,
+
+    /// Optional authentication descriptor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<WebhookAuthConfig>,
+
+    /// Request `Content-Type`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+}
+
+/// Authentication settings for a generic webhook.
+///
+/// The discriminator is serialised as `type` to mirror hushd's existing
+/// `WebhookAuthConfig` schema. Backwards compatible: older agent versions
+/// only emitted `bearer` tokens, which is encoded as `{ type: "bearer",
+/// token: "..." }`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WebhookAuthConfig {
+    #[serde(rename = "type")]
+    pub auth_type: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}

--- a/crates/services/hushd/Cargo.toml
+++ b/crates/services/hushd/Cargo.toml
@@ -32,6 +32,7 @@ clawdstrike-broker-protocol.workspace = true
 hush-multi-agent.workspace = true
 clawdstrike-ocsf.workspace = true
 clawdstrike-policy-event = { workspace = true, features = ["simulate"] }
+clawdstrike-hushd-config.workspace = true
 hush-certification.workspace = true
 spine.workspace = true
 async-nats = "0.40"

--- a/crates/services/hushd/src/config.rs
+++ b/crates/services/hushd/src/config.rs
@@ -4,6 +4,12 @@ use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
+// The Spine attestation-log config is the single source of truth shared with
+// the desktop agent's runtime-config writer. Keeping both sides on the
+// `clawdstrike_hushd_config::SpineConfig` type prevents the daemon from
+// accepting a YAML shape the agent does not produce (or vice-versa).
+pub use clawdstrike_hushd_config::SpineConfig;
+
 use crate::auth::{ApiKey, AuthStore, Scope};
 use crate::siem::dlq::DeadLetterQueueConfig;
 use crate::siem::exporter::ExporterConfig as SiemExporterConfig;
@@ -957,51 +963,6 @@ impl AuditForwardConfig {
         Ok(out)
     }
 }
-/// Spine attestation log configuration.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SpineConfig {
-    /// Whether to publish eval receipts to Spine (NATS JetStream).
-    #[serde(default)]
-    pub enabled: bool,
-    /// NATS server URL (defaults to `nats://127.0.0.1:4222`).
-    #[serde(default)]
-    pub nats_url: Option<String>,
-    /// Path to a `.creds` file for NATS authentication.
-    #[serde(default)]
-    pub creds_file: Option<String>,
-    /// Bearer token for NATS authentication.
-    #[serde(default)]
-    pub token: Option<String>,
-    /// NKey seed for NATS authentication.
-    #[serde(default)]
-    pub nkey_seed: Option<String>,
-    /// Path to a separate Ed25519 keypair for signing spine envelopes.
-    /// When unset, the daemon's signing key is reused.
-    #[serde(default)]
-    pub keypair_path: Option<String>,
-    /// Subject prefix for NATS subjects (default: `spine`).
-    #[serde(default = "default_spine_subject_prefix")]
-    pub subject_prefix: String,
-}
-
-impl Default for SpineConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            nats_url: None,
-            creds_file: None,
-            token: None,
-            nkey_seed: None,
-            keypair_path: None,
-            subject_prefix: default_spine_subject_prefix(),
-        }
-    }
-}
-
-fn default_spine_subject_prefix() -> String {
-    "spine".to_string()
-}
-
 /// Daemon configuration
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1943,5 +1904,125 @@ enabled = false
             }
             _ => panic!("expected otlp sink"),
         }
+    }
+
+    /// Contract test: the runtime config the desktop agent writes (modeled by
+    /// `clawdstrike_hushd_config::RuntimeConfig`) must deserialize cleanly into
+    /// `hushd::config::Config`. If hushd ever adds `deny_unknown_fields` to a
+    /// nested struct or renames a field that the agent populates, this test
+    /// will fail at compile or runtime - which is the whole point of the
+    /// shared crate.
+    #[test]
+    fn agent_runtime_config_yaml_round_trips_into_full_config() {
+        use clawdstrike_hushd_config::{
+            DatadogExporterConfig, ExporterSettings, ExportersConfig, GenericWebhookConfig,
+            RuntimeConfig as AgentRuntimeConfig, SiemConfig as AgentSiemConfig,
+            SpineConfig as AgentSpineConfig, WebhookAuthConfig, WebhookExporterConfig,
+        };
+
+        let agent_view = AgentRuntimeConfig {
+            listen: "127.0.0.1:9876".to_string(),
+            policy_path: Some(PathBuf::from("/etc/clawdstrike/policy.yaml")),
+            ruleset: "default".to_string(),
+            signing_key: Some(PathBuf::from("/var/lib/clawdstrike/sign.key")),
+            siem: Some(AgentSiemConfig {
+                enabled: true,
+                exporters: ExportersConfig {
+                    datadog: Some(ExporterSettings {
+                        enabled: true,
+                        config: DatadogExporterConfig {
+                            api_key: "secret".to_string(),
+                            site: "datadoghq.com".to_string(),
+                        },
+                    }),
+                    webhooks: Some(ExporterSettings {
+                        enabled: true,
+                        config: WebhookExporterConfig {
+                            webhooks: vec![GenericWebhookConfig {
+                                url: "https://example.test/hook".to_string(),
+                                method: Some("POST".to_string()),
+                                headers: Default::default(),
+                                auth: Some(WebhookAuthConfig {
+                                    auth_type: "bearer".to_string(),
+                                    token: Some("token".to_string()),
+                                }),
+                                content_type: Some("application/json".to_string()),
+                            }],
+                        },
+                    }),
+                    ..Default::default()
+                },
+            }),
+            spine: Some(AgentSpineConfig {
+                enabled: true,
+                nats_url: Some("nats://127.0.0.1:4222".to_string()),
+                subject_prefix: "spine".to_string(),
+                ..Default::default()
+            }),
+        };
+
+        let yaml = serde_yaml::to_string(&agent_view).expect("serialise agent view");
+        let hushd_view: Config = serde_yaml::from_str(&yaml).unwrap_or_else(|err| {
+            panic!(
+                "agent-written runtime YAML failed to deserialize into hushd Config: {err}\n--- YAML ---\n{yaml}"
+            )
+        });
+
+        assert_eq!(hushd_view.listen, agent_view.listen);
+        assert_eq!(hushd_view.ruleset, agent_view.ruleset);
+        assert_eq!(hushd_view.policy_path, agent_view.policy_path);
+        assert_eq!(hushd_view.signing_key, agent_view.signing_key);
+
+        let spine = agent_view
+            .spine
+            .as_ref()
+            .expect("agent view spine populated");
+        assert_eq!(hushd_view.spine.enabled, spine.enabled);
+        assert_eq!(hushd_view.spine.nats_url, spine.nats_url);
+        assert_eq!(hushd_view.spine.subject_prefix, spine.subject_prefix);
+
+        let siem = agent_view.siem.as_ref().expect("agent view siem populated");
+        assert_eq!(hushd_view.siem.enabled, siem.enabled);
+
+        let dd_agent = siem.exporters.datadog.as_ref().unwrap();
+        let dd_hushd = hushd_view
+            .siem
+            .exporters
+            .datadog
+            .as_ref()
+            .expect("datadog exporter survives round-trip");
+        assert_eq!(dd_hushd.enabled, dd_agent.enabled);
+        assert_eq!(dd_hushd.config.api_key, dd_agent.config.api_key);
+        assert_eq!(dd_hushd.config.site, dd_agent.config.site);
+
+        let wh_hushd = hushd_view
+            .siem
+            .exporters
+            .webhooks
+            .as_ref()
+            .expect("webhook exporter survives round-trip");
+        assert_eq!(wh_hushd.config.webhooks.len(), 1);
+        assert_eq!(wh_hushd.config.webhooks[0].url, "https://example.test/hook");
+    }
+
+    /// On-disk-backward-compat test: a legacy YAML where `keypair_path` is
+    /// stored as a plain `String` (the previous hushd reader shape) must still
+    /// deserialize cleanly now that the shared type uses `Option<PathBuf>`.
+    #[test]
+    fn spine_keypair_path_legacy_string_round_trips() {
+        let yaml = r#"
+listen: "127.0.0.1:9876"
+ruleset: default
+spine:
+  enabled: true
+  keypair_path: "/var/lib/clawdstrike/spine.key"
+  subject_prefix: "spine"
+"#;
+        let cfg: Config = serde_yaml::from_str(yaml).expect("legacy YAML deserializes");
+        assert_eq!(
+            cfg.spine.keypair_path,
+            Some(PathBuf::from("/var/lib/clawdstrike/spine.key"))
+        );
+        assert!(cfg.spine.enabled);
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 P1-D of the desktop-agent refactor swarm. Extracts the runtime-config DTOs out of `apps/agent/src-tauri/src/daemon.rs` (lines 81-202 in the writer) and `crates/services/hushd/src/config.rs` (the `SpineConfig` reader) into a new workspace crate `clawdstrike-hushd-config` so both sides use one set of types.

Today the desktop agent writes a YAML config that `hushd` must read; the two sides were defining the same field names in separately maintained structs. If one side adds `#[serde(deny_unknown_fields)]`, renames a field, or changes a default, the agent would silently spawn a daemon that refuses to parse the file. The shared crate makes that drift impossible to introduce without a coupled compile-failure.

## Types extracted

From `apps/agent/src-tauri/src/daemon.rs` (lines 81-202, before extraction):

| Agent type (deleted)                         | Shared crate location                       |
| -------------------------------------------- | ------------------------------------------- |
| `HushdRuntimeConfig`                         | `runtime::RuntimeConfig`                    |
| `HushdRuntimeSiemConfig`                     | `siem::SiemConfig`                          |
| `HushdRuntimeExportersConfig`                | `siem::ExportersConfig`                     |
| `HushdRuntimeExporterSettings<T>`            | `siem::ExporterSettings<T>`                 |
| `HushdRuntimeSplunkConfig`                   | `siem::SplunkExporterConfig`                |
| `HushdRuntimeElasticConfig`                  | `siem::ElasticExporterConfig`               |
| `HushdRuntimeElasticAuthConfig`              | `siem::ElasticAuthConfig`                   |
| `HushdRuntimeDatadogConfig`                  | `siem::DatadogExporterConfig`               |
| `HushdRuntimeSumoLogicConfig`                | `siem::SumoLogicExporterConfig`             |
| `HushdRuntimeWebhookExporterConfig`          | `siem::WebhookExporterConfig`               |
| `HushdRuntimeGenericWebhookConfig`           | `webhook::GenericWebhookConfig`             |
| `HushdRuntimeWebhookAuthConfig`              | `webhook::WebhookAuthConfig`                |
| `HushdRuntimeSpineConfig`                    | `spine::SpineConfig`                        |

From `crates/services/hushd/src/config.rs`:

| Hushd type (deleted)        | Shared crate location | Notes |
| --------------------------- | --------------------- | ----- |
| `pub struct SpineConfig`    | `spine::SpineConfig`  | now `pub use clawdstrike_hushd_config::SpineConfig;` |

The bigger `Config`/`SiemSoarConfig`/`SplunkConfig`/etc. types on the hushd reader side intentionally stay in `hushd` because they intertwine with runtime exporter implementations (`DatadogExporter`, `SplunkExporter`, etc.). The shared crate carries only the subset the writer emits; the reader's broader schema remains a strict superset. The contract test below proves the superset still ingests the writer's full output.

## Field divergences and resolutions

| Field                              | Writer (pre-PR)           | Reader (pre-PR)           | Resolution                                                                                              |
| ---------------------------------- | ------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------- |
| `SpineConfig.keypair_path`         | `Option<PathBuf>`         | `Option<String>`          | **Writer wins** (`Option<PathBuf>`). YAML on-disk shape is identical; legacy-string compat verified by test `spine_keypair_path_legacy_string_round_trips`. |
| `RuntimeConfig.policy_path/signing_key` | `Option<PathBuf>`     | `Option<PathBuf>`         | No divergence; carried forward as-is.                                                                  |
| All `#[serde(default)]` defaults   | Mostly missing (Serialize-only) | Mostly present       | **Reader wins** — shared types are `Serialize + Deserialize` and use `#[serde(default, skip_serializing_if = "Option::is_none")]` so the YAML stays compact AND deserializes leniently.       |
| `SpineConfig.subject_prefix` default | none (required)         | `"spine"`                 | **Reader wins** (`default = "spine"`) so the shared type still round-trips without a writer-supplied value. |
| `deny_unknown_fields` on Spine     | n/a                       | not set                   | Intentionally **not** set on shared types so existing on-disk YAML with hushd-only sibling fields (tls, audit, broker, etc.) still parses through `RuntimeConfig`. |

## Backward-compat check (on-disk YAML)

Two tests guard the existing on-disk file format:

- `clawdstrike_hushd_config::runtime::tests::accepts_legacy_yaml_with_unknown_keys` - feeds a YAML containing `tls`, `audit`, `broker` keys (which the writer does not emit but older hushd configs may carry) and asserts `RuntimeConfig` still parses cleanly.
- `hushd::config::tests::spine_keypair_path_legacy_string_round_trips` - feeds a YAML where `spine.keypair_path` is a plain `String` (the previous hushd reader shape) and asserts hushd's `Config` still deserializes it into `Option<PathBuf>`.

A third contract test, `hushd::config::tests::agent_runtime_config_yaml_round_trips_into_full_config`, builds a fully-populated agent view, serializes it to YAML, and deserializes that YAML into hushd's full `Config`. If the writer or reader drifts in a way that breaks the on-disk format, this test fails.

## Test plan

- [x] `cargo test -p clawdstrike-hushd-config` - 4/4 pass (round-trip, minimal, forwards-compat, optional-elision).
- [x] `cargo test -p hushd --lib config::tests` - 16/16 pass including the two new contract tests.
- [x] `cargo test -p clawdstrike-agent daemon::` (run via `apps/agent/src-tauri`) - 30/30 daemon tests pass, including the existing `runtime_siem_config_is_generated_for_datadog_and_webhooks` and `runtime_spine_config_*` tests.
- [x] `cargo build --workspace` - clean.
- [x] `cargo clippy -p clawdstrike-hushd-config -p hushd --lib -- -D warnings` - clean.
- [x] `cargo clippy` on the excluded agent crate - clean.
- [x] `cargo fmt --check` on touched crates - clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the wire format contract for daemon startup (SIEM, Spine, signing paths); mitigated by shared types and YAML round-trip tests, but misalignment could still break agent-managed `hushd` launches.
> 
> **Overview**
> Introduces workspace crate **`clawdstrike-hushd-config`** as the single source of truth for the YAML the desktop agent writes when spawning **`hushd`** (`RuntimeConfig`, SIEM exporter DTOs, webhooks, **`SpineConfig`**).
> 
> **`apps/agent/src-tauri`** drops ~120 lines of private runtime structs in `daemon.rs` and builds the same file using shared types; **`hushd`** depends on the crate and re-exports **`SpineConfig`** instead of defining it locally. Serde defaults and `skip_serializing_if` keep minimal on-disk YAML and tolerate extra daemon-only keys.
> 
> New tests in the shared crate (round-trip, optional omission, unknown keys) and in **`hushd::config`** (agent YAML → full `Config`, legacy string `keypair_path`) lock the writer/reader contract. Lockfiles pick up the new crate and routine transitive bumps (e.g. agent `Cargo.lock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c8733da60f9ee6368d480c7c659b358414ecad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->