### PR TITLE
fix(policy-event): gate wire module on simulate feature

### DIFF
--- a/crates/libs/clawdstrike-policy-event/src/lib.rs
+++ b/crates/libs/clawdstrike-policy-event/src/lib.rs
@@ -24,6 +24,7 @@ pub mod ocsf;
 pub mod simulate;
 pub mod stream;
 pub mod synth;
+#[cfg(feature = "simulate")]
 pub mod wire;
 
 pub use event::*;


### PR DESCRIPTION
The wire module added in #341 imports from \`crate::simulate\` (\`SimulationResult\`, \`DecisionInfo\`) which is itself feature-gated on \`simulate\`. WASM builds (\`--no-default-features\`) currently fail with E0432 unresolved imports.

Gate the entire \`wire\` module on the \`simulate\` feature. Verified the only consumer building without simulate is \`hush-wasm\`, which doesn't use wire types directly.

Verified locally:
- \`cargo build -p clawdstrike-policy-event --no-default-features\` clean
- \`cargo build -p clawdstrike-policy-event\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional export in the crate root; no runtime or security behavior change.
> 
> **Overview**
> **Fixes** a compile failure when building `clawdstrike-policy-event` with `--no-default-features` (e.g. WASM): the `wire` module was always exported but its code imports `crate::simulate`, which is only available with the `simulate` feature.
> 
> The change **gates** `pub mod wire` behind `#[cfg(feature = "simulate")]`, matching `simulate` and the rest of the simulation stack. Default-feature builds are unchanged; minimal-feature consumers no longer pull in `wire` or hit unresolved imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d5d6d9a4d5f021eced75ad4222cda7cc9b4556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->