### PR TITLE
fix: address bot review feedback on refactor PRs

### DIFF
--- a/apps/agent/src-tauri/src/api_server/control_sync/receipt_upload.rs
+++ b/apps/agent/src-tauri/src/api_server/control_sync/receipt_upload.rs
@@ -12,11 +12,14 @@ pub(crate) async fn enqueue_control_receipt_upload_retry(
     receipt: &ControlStoreReceiptRequest,
     failure: ControlReceiptUploadAttemptFailure,
 ) -> Result<(String, chrono::DateTime<chrono::Utc>), (StatusCode, String)> {
-    let receipt_hash = canonical_json_hash(
-        &receipt.signed_receipt,
-        "control receipt upload signed receipt",
-    )
-    .map_err(internal_error)?;
+    let signed_receipt = receipt.signed_receipt.as_ref().ok_or_else(|| {
+        internal_error(anyhow::anyhow!(
+            "control receipt upload retry requires signed_receipt"
+        ))
+    })?;
+    let receipt_hash =
+        canonical_json_hash(signed_receipt, "control receipt upload signed receipt")
+            .map_err(internal_error)?;
     let receipt_id = receipt
         .metadata
         .as_ref()

--- a/apps/agent/src-tauri/src/api_server/receipts/control_store.rs
+++ b/apps/agent/src-tauri/src/api_server/receipts/control_store.rs
@@ -59,7 +59,7 @@ pub(crate) fn control_store_receipt_from_endpoint_receipt(
             "endpointId": receipt_endpoint_decision_str(receipt, &["actor", "endpointId"]),
             "policyHash": receipt_endpoint_decision_str(receipt, &["policy", "policyHash"]),
         })),
-        signed_receipt,
+        signed_receipt: Some(signed_receipt),
     })
 }
 

--- a/apps/agent/src-tauri/src/api_server/tests/policy_events/part_3.rs
+++ b/apps/agent/src-tauri/src/api_server/tests/policy_events/part_3.rs
@@ -1224,8 +1224,12 @@
         assert!(queued[0].receipt_hash.starts_with("0x"));
         assert_eq!(queued[0].last_http_status, Some(503));
         assert_eq!(
-            queued[0].payload.signed_receipt["receipt"]["metadata"]["endpointDecision"]
-                ["receiptFamily"],
+            queued[0]
+                .payload
+                .signed_receipt
+                .as_ref()
+                .expect("queued payload always carries signed_receipt")
+                ["receipt"]["metadata"]["endpointDecision"]["receiptFamily"],
             "detection"
         );
 

--- a/crates/libs/clawdstrike-control-protocol/src/ledger.rs
+++ b/crates/libs/clawdstrike-control-protocol/src/ledger.rs
@@ -82,7 +82,10 @@ mod tests {
             ..Default::default()
         };
         let json = serde_json::to_string(&record).unwrap();
-        assert!(json.contains("\"receiptId\""), "expected camelCase, got {json}");
+        assert!(
+            json.contains("\"receiptId\""),
+            "expected camelCase, got {json}"
+        );
         assert!(json.contains("\"localSequence\""));
         let back: EndpointReceiptIndexRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(back, record);

--- a/crates/libs/clawdstrike-control-protocol/src/receipt.rs
+++ b/crates/libs/clawdstrike-control-protocol/src/receipt.rs
@@ -29,7 +29,15 @@ use serde_json::Value;
 /// posts it to the Control API for durable storage. The Control API
 /// re-verifies the signature against the embedded `signed_receipt` before
 /// persisting.
+///
+/// `signed_receipt` is `Option<Value>` on the wire (not required at the
+/// deserializer level) so that requests missing the field surface as the
+/// handler's `ApiError::BadRequest` (HTTP 400 with a JSON envelope), matching
+/// the original control-api contract before this crate was extracted. Making
+/// it required here would force Axum's `Json<>` extractor to short-circuit
+/// with a default 422 response, breaking clients that depend on the 400.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ControlStoreReceiptRequest {
     /// RFC 3339 timestamp from the original receipt.
     pub timestamp: String,
@@ -52,14 +60,17 @@ pub struct ControlStoreReceiptRequest {
     /// Optional metadata payload (e.g. `receiptId`, source, policy hash).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
-    /// The full signed receipt envelope. Required — the control-api
-    /// validation pipeline rejects payloads where this is missing, so we
-    /// model the requirement at the type level.
-    pub signed_receipt: Value,
+    /// The signed receipt envelope. Producers always emit one; the receiver's
+    /// `validate_store_request` rejects payloads with this missing as HTTP 400.
+    /// Kept optional here so the rejection happens in the handler, not the
+    /// deserializer, preserving the prior 400 contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signed_receipt: Option<Value>,
 }
 
 /// Request body for `POST /api/v1/receipts/batch`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ControlBatchStoreReceiptsRequest {
     /// Receipts to store, processed in order.
     pub receipts: Vec<ControlStoreReceiptRequest>,
@@ -81,7 +92,7 @@ mod tests {
             chain_hash: None,
             evidence: None,
             metadata: None,
-            signed_receipt: serde_json::json!({"signed": true}),
+            signed_receipt: Some(serde_json::json!({"signed": true})),
         };
         let bytes = serde_json::to_vec(&req).unwrap();
         let back: ControlStoreReceiptRequest = serde_json::from_slice(&bytes).unwrap();
@@ -90,7 +101,10 @@ mod tests {
     }
 
     #[test]
-    fn store_receipt_request_rejects_missing_signed_receipt() {
+    fn store_receipt_request_accepts_missing_signed_receipt() {
+        // Deliberately not required at the deserializer level so the handler
+        // can return HTTP 400 (instead of Axum's default 422) for missing
+        // signed_receipt. See struct doc-comment.
         let raw = serde_json::json!({
             "timestamp": "2026-05-26T00:00:00Z",
             "verdict": "allow",
@@ -99,10 +113,26 @@ mod tests {
             "signature": "ab",
             "public_key": "cd",
         });
+        let req: ControlStoreReceiptRequest = serde_json::from_value(raw).unwrap();
+        assert!(req.signed_receipt.is_none());
+    }
+
+    #[test]
+    fn store_receipt_request_rejects_unknown_fields() {
+        let raw = serde_json::json!({
+            "timestamp": "2026-05-26T00:00:00Z",
+            "verdict": "allow",
+            "guard": "endpoint_decision",
+            "policy_name": "default",
+            "signature": "ab",
+            "public_key": "cd",
+            "signed_receipt": {},
+            "unexpected_field": "boom",
+        });
         let err = serde_json::from_value::<ControlStoreReceiptRequest>(raw).unwrap_err();
         assert!(
-            err.to_string().contains("signed_receipt"),
-            "expected missing-field error to mention signed_receipt, got {err}"
+            err.to_string().contains("unexpected_field"),
+            "expected unknown-field rejection, got {err}"
         );
     }
 
@@ -119,7 +149,7 @@ mod tests {
                 chain_hash: Some("0xdeadbeef".to_string()),
                 evidence: Some(serde_json::json!([])),
                 metadata: Some(serde_json::json!({"receiptId": "abc"})),
-                signed_receipt: serde_json::json!({}),
+                signed_receipt: Some(serde_json::json!({})),
             }],
         };
         let bytes = serde_json::to_vec(&batch).unwrap();

--- a/crates/libs/clawdstrike-hushd-config/src/runtime.rs
+++ b/crates/libs/clawdstrike-hushd-config/src/runtime.rs
@@ -55,6 +55,7 @@ impl RuntimeConfig {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::siem::{

--- a/crates/libs/clawdstrike-policy-event/src/wire/deception.rs
+++ b/crates/libs/clawdstrike-policy-event/src/wire/deception.rs
@@ -3,8 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::edr::{
-    DeceptionCleanupReport, DeceptionMaterializationReport, DeceptionPlan,
-    DeceptionRotationReport,
+    DeceptionCleanupReport, DeceptionMaterializationReport, DeceptionPlan, DeceptionRotationReport,
 };
 use hush_core::SignedReceipt;
 

--- a/crates/libs/clawdstrike-policy-event/src/wire/endpoint_security.rs
+++ b/crates/libs/clawdstrike-policy-event/src/wire/endpoint_security.rs
@@ -4,9 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::edr::{
-    DetectionFinding, EndpointObservation, EndpointProcess, HoneyArtifact,
-};
+use crate::edr::{DetectionFinding, EndpointObservation, EndpointProcess, HoneyArtifact};
 use hush_core::SignedReceipt;
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/libs/clawdstrike-policy-event/src/wire/findings.rs
+++ b/crates/libs/clawdstrike-policy-event/src/wire/findings.rs
@@ -2,9 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::edr::{
-    CausalGraph, DetectionFinding, EndpointObservation, HoneyArtifact,
-};
+use crate::edr::{CausalGraph, DetectionFinding, EndpointObservation, HoneyArtifact};
 use hush_core::SignedReceipt;
 
 use super::policy_event_history::{

--- a/crates/libs/clawdstrike-policy-event/src/wire/network_extension.rs
+++ b/crates/libs/clawdstrike-policy-event/src/wire/network_extension.rs
@@ -4,9 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::edr::{
-    DetectionFinding, EndpointObservation, EndpointProcess, HoneyArtifact,
-};
+use crate::edr::{DetectionFinding, EndpointObservation, EndpointProcess, HoneyArtifact};
 use hush_core::SignedReceipt;
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/libs/clawdstrike-policy-event/src/wire/policy_event_history_causal.rs
+++ b/crates/libs/clawdstrike-policy-event/src/wire/policy_event_history_causal.rs
@@ -7,7 +7,9 @@ use std::collections::BTreeMap;
 
 use serde::Serialize;
 
-use crate::edr::{CausalGraph, CausalNodeKind, EndpointDecisionAction, EndpointSimulationImpactLevel};
+use crate::edr::{
+    CausalGraph, CausalNodeKind, EndpointDecisionAction, EndpointSimulationImpactLevel,
+};
 use hush_core::SignedReceipt;
 
 use super::policy_event_history::{

--- a/crates/libs/clawdstrike-policy-event/src/wire/policy_events.rs
+++ b/crates/libs/clawdstrike-policy-event/src/wire/policy_events.rs
@@ -2,9 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::edr::{
-    DetectionFinding, EndpointObservation, EndpointPolicySnapshot, HoneyArtifact,
-};
+use crate::edr::{DetectionFinding, EndpointObservation, EndpointPolicySnapshot, HoneyArtifact};
 use crate::event::PolicyEvent;
 use crate::simulate::{DecisionInfo, SimulationResult};
 use hush_core::SignedReceipt;

--- a/crates/libs/clawdstrike-policy-event/src/wire/response_actions.rs
+++ b/crates/libs/clawdstrike-policy-event/src/wire/response_actions.rs
@@ -8,9 +8,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::edr::{
-    CausalGraph, EndpointDecisionAction, EndpointGraphReference, EndpointResponseAcknowledgementReport,
-    EndpointResponseExecutionReport, EndpointResponsePlan, EndpointResponseRollbackReport,
-    EndpointSensorState,
+    CausalGraph, EndpointDecisionAction, EndpointGraphReference,
+    EndpointResponseAcknowledgementReport, EndpointResponseExecutionReport, EndpointResponsePlan,
+    EndpointResponseRollbackReport, EndpointSensorState,
 };
 use hush_core::SignedReceipt;
 
@@ -311,9 +311,7 @@ pub struct EdrResponseAcknowledgementRecord {
 }
 
 impl EdrResponseAcknowledgementRecord {
-    pub fn from_acknowledgement(
-        acknowledgement: EndpointResponseAcknowledgementReport,
-    ) -> Self {
+    pub fn from_acknowledgement(acknowledgement: EndpointResponseAcknowledgementReport) -> Self {
         Self { acknowledgement }
     }
 }

--- a/crates/services/control-api/src/routes/receipts.rs
+++ b/crates/services/control-api/src/routes/receipts.rs
@@ -504,6 +504,10 @@ fn validate_store_request(req: &StoreReceiptRequest) -> Result<(), ApiError> {
             "policy_name must not be empty".to_string(),
         ));
     }
+    let signed_receipt_value = req
+        .signed_receipt
+        .as_ref()
+        .ok_or_else(|| ApiError::BadRequest("signed_receipt is required".to_string()))?;
 
     // Validate verdict against an allow-list.
     if !matches!(req.verdict.as_str(), "allow" | "deny" | "warn") {
@@ -524,7 +528,7 @@ fn validate_store_request(req: &StoreReceiptRequest) -> Result<(), ApiError> {
         ApiError::BadRequest("invalid signature: not a valid Ed25519 signature hex".to_string())
     })?;
 
-    let signed_receipt: SignedReceipt = serde_json::from_value(req.signed_receipt.clone())
+    let signed_receipt: SignedReceipt = serde_json::from_value(signed_receipt_value.clone())
         .map_err(|e| ApiError::BadRequest(format!("invalid signed_receipt: {}", e)))?;
 
     if signed_receipt.signatures.signer.to_hex() != req.signature {
@@ -570,7 +574,7 @@ fn stored_receipt_from_request(tenant_id: Uuid, req: StoreReceiptRequest) -> Sto
         chain_hash: req.chain_hash,
         evidence: req.evidence,
         metadata: req.metadata,
-        signed_receipt: Some(req.signed_receipt),
+        signed_receipt: req.signed_receipt,
     }
 }
 
@@ -821,17 +825,17 @@ mod tests {
             chain_hash: None,
             evidence: None,
             metadata: None,
-            signed_receipt: serde_json::Value::Null,
+            signed_receipt: None,
         };
         assert!(validate_store_request(&req).is_err());
     }
 
     #[test]
-    fn deserialize_rejects_missing_signed_receipt() {
-        // Previously this was tested at the handler level via
-        // `validate_store_request`. Now that `signed_receipt` is a required
-        // field on the shared protocol type, the deserializer rejects
-        // payloads missing it before any handler logic runs.
+    fn handler_rejects_missing_signed_receipt() {
+        // signed_receipt is intentionally Option at the deserializer so the
+        // handler can return HTTP 400 (instead of Axum's 422) when it's
+        // missing. Confirm the parse succeeds and validate_store_request
+        // then rejects with BadRequest.
         let raw = serde_json::json!({
             "timestamp": "2026-03-09T00:00:00Z",
             "verdict": "allow",
@@ -840,11 +844,13 @@ mod tests {
             "signature": "abcd",
             "public_key": "deadbeef",
         });
-        let err = serde_json::from_value::<StoreReceiptRequest>(raw).unwrap_err();
-        assert!(
-            err.to_string().contains("signed_receipt"),
-            "expected missing-field error on signed_receipt, got {err}"
-        );
+        let req: StoreReceiptRequest = serde_json::from_value(raw).unwrap();
+        assert!(req.signed_receipt.is_none());
+        let err = validate_store_request(&req).unwrap_err();
+        match err {
+            ApiError::BadRequest(msg) => assert!(msg.contains("signed_receipt")),
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
     }
 
     fn make_signed_store_request(verdict: &str) -> StoreReceiptRequest {
@@ -870,7 +876,7 @@ mod tests {
             chain_hash: None,
             evidence: None,
             metadata: None,
-            signed_receipt: serde_json::to_value(&signed_receipt).unwrap(),
+            signed_receipt: Some(serde_json::to_value(&signed_receipt).unwrap()),
         }
     }
 
@@ -882,11 +888,11 @@ mod tests {
 
     #[test]
     fn validate_requires_well_formed_signed_receipt() {
-        // The `signed_receipt` field is required at deserialize-time on the
-        // shared protocol type, so the runtime check now exercises the
-        // "field present but not a valid signed receipt" path.
+        // Field is Option on the wire (so missing produces handler-level 400,
+        // not Axum's default 422); validation still rejects either missing
+        // (None) or malformed (Some(invalid)) payloads as BadRequest.
         let mut req = make_signed_store_request("allow");
-        req.signed_receipt = serde_json::Value::Null;
+        req.signed_receipt = None;
         let err = validate_store_request(&req).unwrap_err();
         assert!(matches!(err, ApiError::BadRequest(_)));
     }


### PR DESCRIPTION
Bundles three fixes for issues surfaced by Codex Review and Cursor Bugbot on the recently-merged refactor PRs (#338-#353).

## Issues addressed

### 1. \`deny_unknown_fields\` regression (PR #338)
The old \`StoreReceiptRequest\` in control-api had \`#[serde(deny_unknown_fields)]\`. The extracted \`ControlStoreReceiptRequest\` and \`ControlBatchStoreReceiptsRequest\` lost it. Restored so extra JSON keys still reject at the deserializer.

### 2. 400 → 422 wire-level regression (PR #338)
Making \`signed_receipt\` required in the shared crate moved rejection from \`validate_store_request\` (HTTP 400 + JSON envelope) to Axum's \`Json<>\` extractor (HTTP 422 default). Reverted to \`Option<Value>\` so missing field returns 400 from the handler. Moved the \`None\` check up in \`validate_store_request\` so it fires before crypto-shape validation.

### 3. cargo fmt violations
Wire/ submodule extraction (PR #341) and a trailing assert in \`clawdstrike-control-protocol\` introduced fmt issues. \`cargo fmt --all\` clean now.

## Tests added

- \`store_receipt_request_accepts_missing_signed_receipt\` — deserialize OK when field missing
- \`store_receipt_request_rejects_unknown_fields\` — \`deny_unknown_fields\` works
- \`handler_rejects_missing_signed_receipt\` — \`validate_store_request\` returns BadRequest (preserving the 400 contract)

## Verification

- \`cargo build --workspace\` clean
- \`cargo test -p clawdstrike-control-protocol\` 12/12 passed
- \`cargo test -p clawdstrike-control-api receipts\` 24/24 passed
- \`cargo fmt --all --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The shown change is a single test assertion update; no production behavior changes in this diff hunk.
> 
> **Overview**
> Updates the **`failed_auto_receipt_upload_is_queued_and_retried`** EDR test so queued control upload payloads read **`receiptFamily`** through **`signed_receipt` as an `Option`**, using **`.as_ref().expect(...)`** before indexing JSON—aligned with making **`signed_receipt`** optional on store/retry types so missing values stay handler-validated (**HTTP 400**) instead of failing at Axum JSON extraction.
> 
> This diff is test-only; the same PR (per description) also restores **`deny_unknown_fields`**, keeps the **400** wire contract for absent **`signed_receipt`**, adds protocol/handler tests, and runs **`cargo fmt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b6d4328c40f20296abfab38528f2a82061e7ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->