### PR TITLE
refactor(daemon): narrow audit_queue visibility + clean sleep_or_shutdown import

### DIFF
--- a/apps/agent/src-tauri/src/daemon/audit_queue.rs
+++ b/apps/agent/src-tauri/src/daemon/audit_queue.rs
@@ -16,15 +16,15 @@ use tokio::sync::Mutex;
 /// Stores events that were generated while hushd was unreachable so they
 /// can be uploaded when connectivity is restored.
 pub struct AuditQueue {
-    pub(super) path: PathBuf,
-    pub(super) queue: Mutex<VecDeque<serde_json::Value>>,
+    path: PathBuf,
+    queue: Mutex<VecDeque<serde_json::Value>>,
     flush_lock: Mutex<()>,
     http_client: reqwest::Client,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub(super) struct PersistedAuditQueue {
-    pub(super) entries: VecDeque<serde_json::Value>,
+struct PersistedAuditQueue {
+    entries: VecDeque<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -66,8 +66,8 @@ impl fmt::Display for AuditFlushProgressError {
 
 impl std::error::Error for AuditFlushProgressError {}
 
-pub(super) const MAX_AUDIT_QUEUE_LEN: usize = 10_000;
-pub(super) const MAX_AUDIT_BATCH_LEN: usize = 5_000;
+const MAX_AUDIT_QUEUE_LEN: usize = 10_000;
+const MAX_AUDIT_BATCH_LEN: usize = 5_000;
 
 fn audit_flush_has_prior_progress(outcome: AuditFlushOutcome) -> bool {
     outcome.accepted > 0 || outcome.duplicates > 0 || outcome.rejected > 0
@@ -115,7 +115,7 @@ fn load_persisted_audit_queue(path: &Path) -> (VecDeque<serde_json::Value>, bool
     }
 }
 
-pub(super) fn persist_audit_queue(path: &Path, queue: &VecDeque<serde_json::Value>) -> Result<()> {
+fn persist_audit_queue(path: &Path, queue: &VecDeque<serde_json::Value>) -> Result<()> {
     let serialized = serde_json::to_string_pretty(&PersistedAuditQueue {
         entries: queue.clone(),
     })
@@ -227,7 +227,7 @@ fn drain_flush_batch(
 }
 
 impl AuditQueue {
-    pub(super) fn with_path(path: PathBuf) -> Self {
+    fn with_path(path: PathBuf) -> Self {
         let (queue, sanitized) = load_persisted_audit_queue(&path);
         if sanitized {
             if let Err(err) = persist_audit_queue(&path, &queue) {

--- a/apps/agent/src-tauri/src/daemon/manager.rs
+++ b/apps/agent/src-tauri/src/daemon/manager.rs
@@ -13,8 +13,8 @@ use tokio::process::Child;
 use tokio::sync::{broadcast, Mutex, RwLock};
 
 use super::ready_probe::{
-    health_check_with_client, wait_for_ready_with_client, wait_for_ready_with_client_or_shutdown,
-    ReadyWaitOutcome,
+    health_check_with_client, sleep_or_shutdown, wait_for_ready_with_client,
+    wait_for_ready_with_client_or_shutdown, ReadyWaitOutcome,
 };
 use super::runtime_keypair::cleanup_runtime_enrollment_keypair;
 use super::spawn::{
@@ -321,7 +321,7 @@ impl DaemonManager {
 
                                 let backoff = compute_backoff(restart_streak, next_restart_count);
                                 tracing::info!(backoff_ms = backoff.as_millis() as u64, "Scheduling hushd restart");
-                                if super::ready_probe::sleep_or_shutdown(&mut shutdown_rx, backoff).await {
+                                if sleep_or_shutdown(&mut shutdown_rx, backoff).await {
                                     tracing::debug!("Shutdown requested while waiting to restart hushd");
                                     break 'monitor;
                                 }


### PR DESCRIPTION
## Summary

Cleanup pass for the two P2 nits identified in the bot-class review of merged PR #345 (`refactor(agent): split daemon.rs into daemon/{manager,policy_cache,audit_queue,...}`). No behavior change.

### P2-1 — Narrow `audit_queue.rs` `pub(super)` over-promotions

The visibility promotions added in PR #345 were defensive over-corrections: the `#[path = "audit_queue_tests.rs"]` child module is declared **inside** `daemon::audit_queue` (line 499-501), so it can already access parent private items via `super::*` without any `pub(super)` markers.

Dropped to private (kept verified compiling & test-passing):

- `AuditQueue::path`
- `AuditQueue::queue`
- `PersistedAuditQueue` struct
- `PersistedAuditQueue::entries`
- `MAX_AUDIT_QUEUE_LEN`
- `MAX_AUDIT_BATCH_LEN`
- `persist_audit_queue`
- `AuditQueue::with_path`

### P2-2 — Fix `manager.rs` `sleep_or_shutdown` import

`manager.rs:324` was the only call site using a fully-qualified `super::ready_probe::sleep_or_shutdown(...)` path. The other four ready_probe siblings (`health_check_with_client`, `wait_for_ready_with_client`, `wait_for_ready_with_client_or_shutdown`, `ReadyWaitOutcome`) were imported on lines 15-18. Added `sleep_or_shutdown` to the existing import block; call site now uses the short name.

## Test plan

- [x] `cargo build --bin clawdstrike-agent` — clean
- [x] `cargo clippy --bin clawdstrike-agent -- -D warnings` — clean
- [x] `cargo test --bins daemon::` — 30/30 pass (identical test count to PR #345 baseline)
- [x] `rustfmt --check` on modified files — clean

Bot review report: `/tmp/review-pr345.md`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility and import-only edits with no logic changes; low impact on daemon lifecycle or audit flushing.
> 
> **Overview**
> Follow-up cleanup after the daemon module split: **no behavior change**.
> 
> In **`audit_queue.rs`**, several items that were marked `pub(super)` are made **module-private** again (`AuditQueue` fields, `PersistedAuditQueue`, queue limits, `persist_audit_queue`, `with_path`). The in-module test child (`audit_queue_tests` via `#[path]`) still reaches them through `super::*`.
> 
> In **`manager.rs`**, **`sleep_or_shutdown`** is imported alongside the other `ready_probe` helpers and the restart backoff call uses the short name instead of `super::ready_probe::sleep_or_shutdown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8c8111d895ac1895aa682b091a5787994b48849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->