### PR TITLE
refactor(response-actions): narrow visibility + remove TerminateProcessTree inconsistency

### DIFF
--- a/apps/agent/src-tauri/src/api_server/response_actions/dispatch.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/dispatch.rs
@@ -19,12 +19,19 @@ pub(crate) fn supported_edr_simulation_action(action: &EndpointDecisionAction) -
     )
 }
 
+// NOTE: `TerminateProcessTree` is intentionally absent from
+// `supported_edr_response_action` and the `default_response_action_reason`
+// match below. The dispatcher has no `TerminateProcessTree =>` execute arm
+// and the handler-level allowlist (`edr/handlers/response/action.rs`)
+// already excludes it from non-dry-run execution. Keeping it out of these
+// tables makes that intent explicit instead of relying on the handler to
+// gate the inconsistency. Simulation continues to support
+// `TerminateProcessTree` (audit-stage policy promotion).
 pub(crate) fn supported_edr_response_action(action: &EndpointDecisionAction) -> bool {
     matches!(
         action,
         EndpointDecisionAction::RestrictEgress
             | EndpointDecisionAction::SuspendProcessTree
-            | EndpointDecisionAction::TerminateProcessTree
             | EndpointDecisionAction::QuarantineFile
             | EndpointDecisionAction::RevokeGrant
             | EndpointDecisionAction::DisablePersistence
@@ -46,7 +53,6 @@ pub(crate) fn default_response_action_reason(
         EndpointDecisionAction::DisablePersistence => "disable endpoint persistence item",
         EndpointDecisionAction::RevokeGrant => "revoke local endpoint grant",
         EndpointDecisionAction::SuspendProcessTree => "suspend endpoint process tree",
-        EndpointDecisionAction::TerminateProcessTree => "terminate endpoint process tree",
         _ => "execute endpoint response",
     }
 }

--- a/apps/agent/src-tauri/src/api_server/response_actions/egress_match.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/egress_match.rs
@@ -39,7 +39,7 @@ pub(crate) fn policy_output_for_active_egress_restriction(
     }
 }
 
-pub(crate) fn restrict_egress_targets(
+pub(super) fn restrict_egress_targets(
     plan: &EndpointResponsePlan,
     graph: &CausalGraph,
 ) -> Result<Vec<String>> {
@@ -104,7 +104,7 @@ fn normalize_egress_policy_target(action_type: &str, target: &str) -> Option<Str
     normalize_egress_target(target.as_str()).ok()
 }
 
-pub(crate) fn normalize_egress_target(target: &str) -> Result<String> {
+pub(super) fn normalize_egress_target(target: &str) -> Result<String> {
     let target = target.trim();
     if target.is_empty() {
         return Err(anyhow::anyhow!("egress target must not be empty"));

--- a/apps/agent/src-tauri/src/api_server/response_actions/execute/disable_persistence.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/execute/disable_persistence.rs
@@ -97,7 +97,7 @@ pub(crate) async fn execute_disable_persistence_response(
     ))
 }
 
-pub(crate) fn disable_persistence_target_path(
+pub(super) fn disable_persistence_target_path(
     plan: &EndpointResponsePlan,
     graph: &CausalGraph,
 ) -> Result<PathBuf> {
@@ -144,7 +144,7 @@ fn browser_extension_manifest_target_path(path: PathBuf) -> PathBuf {
     }
 }
 
-pub(crate) fn validate_disable_persistence_source_path(path: &FsPath) -> Result<()> {
+pub(super) fn validate_disable_persistence_source_path(path: &FsPath) -> Result<()> {
     let metadata = fs::symlink_metadata(path)
         .with_context(|| format!("stat persistence target {}", path.display()))?;
     if metadata.file_type().is_symlink() {
@@ -168,7 +168,7 @@ pub(crate) fn validate_disable_persistence_source_path(path: &FsPath) -> Result<
     Ok(())
 }
 
-pub(crate) fn persistence_disable_destination_path(
+pub(super) fn persistence_disable_destination_path(
     quarantine_root: &FsPath,
     plan: &EndpointResponsePlan,
     source_path: &FsPath,

--- a/apps/agent/src-tauri/src/api_server/response_actions/execute/quarantine_file.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/execute/quarantine_file.rs
@@ -92,7 +92,7 @@ pub(crate) async fn execute_quarantine_file_response(
     ))
 }
 
-pub(crate) fn validate_quarantine_source_path(path: &FsPath) -> Result<()> {
+pub(super) fn validate_quarantine_source_path(path: &FsPath) -> Result<()> {
     let metadata = fs::symlink_metadata(path)
         .with_context(|| format!("stat quarantine target {}", path.display()))?;
     if metadata.file_type().is_symlink() {
@@ -116,7 +116,9 @@ pub(crate) fn validate_quarantine_source_path(path: &FsPath) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn path_is_bounded_quarantine_source(path: &FsPath) -> bool {
+pub(in crate::api_server::response_actions) fn path_is_bounded_quarantine_source(
+    path: &FsPath,
+) -> bool {
     let normalized = path.display().to_string().replace('\\', "/");
     let temp_dir = std::env::temp_dir()
         .display()
@@ -134,7 +136,7 @@ pub(crate) fn path_is_bounded_quarantine_source(path: &FsPath) -> bool {
         || normalized.contains("/target/release/")
 }
 
-pub(crate) fn validate_quarantine_artifact_path(
+pub(in crate::api_server::response_actions) fn validate_quarantine_artifact_path(
     quarantine_root: &FsPath,
     artifact_path: &FsPath,
 ) -> Result<(), (StatusCode, String)> {

--- a/apps/agent/src-tauri/src/api_server/response_actions/failure.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/failure.rs
@@ -118,6 +118,6 @@ fn response_failure_token_byte(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.')
 }
 
-pub(crate) fn sanitize_brokerd_error_body(body: &str) -> String {
+pub(super) fn sanitize_brokerd_error_body(body: &str) -> String {
     sanitize_response_execution_failure(body)
 }

--- a/apps/agent/src-tauri/src/api_server/response_actions/mod.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/mod.rs
@@ -16,10 +16,10 @@
 //! `clawdstrike-fs-policy-paths` crate (extracted in Phase 1).
 //!
 //! Sub-files import the parent api_server scope via `use super::*;`, which
-//! re-exports `super::super::*` here so they see all the same symbols the
-//! original single-file module relied on.
+//! sees `super::*` here -- making the parent api_server symbols visible inside
+//! `response_actions` without re-broadcasting them back through this module.
 
-pub(crate) use super::*;
+use super::*;
 
 pub(crate) use clawdstrike_fs_policy_paths::path_is_bounded_persistence_target;
 

--- a/apps/agent/src-tauri/src/api_server/response_actions/persistence.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/persistence.rs
@@ -120,7 +120,7 @@ pub(crate) async fn record_edr_response_rollback_failure(
     Ok((failed, receipt))
 }
 
-pub(crate) fn response_execution_transition_id(
+pub(super) fn response_execution_transition_id(
     prefix: &str,
     response_action_id: &str,
     evidence_bundle_id: &str,

--- a/apps/agent/src-tauri/src/api_server/response_actions/process_signal.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/process_signal.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-pub(crate) fn validate_process_signal_targets(targets: &[ProcessSignalTarget]) -> Result<()> {
+pub(super) fn validate_process_signal_targets(targets: &[ProcessSignalTarget]) -> Result<()> {
     if targets.is_empty() {
         return Err(anyhow::anyhow!(
             "process tree has no signalable process nodes"
@@ -38,14 +38,14 @@ pub(crate) fn validate_process_signal_targets(targets: &[ProcessSignalTarget]) -
     Ok(())
 }
 
-pub(crate) fn validate_process_signal_target_before_signal(
+pub(super) fn validate_process_signal_target_before_signal(
     target: &ProcessSignalTarget,
 ) -> Result<()> {
     validate_process_identity_binding(target.pid, Some(target.process_identity_key.as_str()))?;
     check_process_signalable(target.pid)
 }
 
-pub(crate) fn validate_process_effect_signal_target_before_signal(
+pub(super) fn validate_process_effect_signal_target_before_signal(
     target: &ProcessTreeEffectSignalTarget,
 ) -> Result<()> {
     validate_process_identity_binding(target.pid, target.process_identity_key.as_deref())?;
@@ -111,22 +111,22 @@ fn current_parent_pid() -> Option<u32> {
 }
 
 #[cfg(unix)]
-pub(crate) fn process_suspend_signal() -> i32 {
+pub(super) fn process_suspend_signal() -> i32 {
     libc::SIGSTOP
 }
 
 #[cfg(not(unix))]
-pub(crate) fn process_suspend_signal() -> i32 {
+pub(super) fn process_suspend_signal() -> i32 {
     0
 }
 
 #[cfg(unix)]
-pub(crate) fn process_resume_signal() -> i32 {
+pub(super) fn process_resume_signal() -> i32 {
     libc::SIGCONT
 }
 
 #[cfg(not(unix))]
-pub(crate) fn process_resume_signal() -> i32 {
+pub(super) fn process_resume_signal() -> i32 {
     0
 }
 
@@ -143,7 +143,7 @@ fn check_process_signalable(_pid: u32) -> Result<()> {
 }
 
 #[cfg(unix)]
-pub(crate) fn signal_process(pid: u32, signal: i32) -> Result<()> {
+pub(super) fn signal_process(pid: u32, signal: i32) -> Result<()> {
     let pid = i32::try_from(pid).context("pid exceeds platform signal range")?;
     let result = unsafe { libc::kill(pid, signal) };
     if result == 0 {
@@ -160,7 +160,7 @@ pub(crate) fn signal_process(pid: u32, signal: i32) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-pub(crate) fn signal_process(_pid: u32, _signal: i32) -> Result<()> {
+pub(super) fn signal_process(_pid: u32, _signal: i32) -> Result<()> {
     Err(anyhow::anyhow!(
         "process signalling is only supported on Unix platforms"
     ))

--- a/apps/agent/src-tauri/src/api_server/response_actions/rollback/disable_persistence.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/rollback/disable_persistence.rs
@@ -99,7 +99,7 @@ pub(crate) fn execute_disable_persistence_rollback(
     Ok(rollback)
 }
 
-pub(crate) fn validate_disable_persistence_restore_target_path(path: &FsPath) -> Result<()> {
+pub(super) fn validate_disable_persistence_restore_target_path(path: &FsPath) -> Result<()> {
     if !path.is_absolute() {
         return Err(anyhow::anyhow!(
             "persistence rollback target path must be absolute: {}",

--- a/apps/agent/src-tauri/src/api_server/response_actions/rollback/quarantine_file.rs
+++ b/apps/agent/src-tauri/src/api_server/response_actions/rollback/quarantine_file.rs
@@ -89,7 +89,7 @@ pub(crate) fn execute_quarantine_file_rollback(
     Ok(rollback)
 }
 
-pub(crate) fn validate_quarantine_restore_target_path(path: &FsPath) -> Result<()> {
+pub(super) fn validate_quarantine_restore_target_path(path: &FsPath) -> Result<()> {
     if !path.is_absolute() {
         return Err(anyhow::anyhow!(
             "rollback target path must be absolute: {}",


### PR DESCRIPTION
## Summary

Cleanup fixes for the P2 nits identified in the bot-class review of merged PR #343 (response_actions split). Full report at `/tmp/review-pr343.md`.

- **P2-1**: change `response_actions/mod.rs` from `pub(crate) use super::*;` to `use super::*;` -- parent api_server symbols stay visible inside response_actions without being re-broadcast back through it, eliminating the circular re-export surface with `api_server.rs:127`'s `pub(crate) use response_actions::*;`.
- **P2-2**: narrow 18 helpers from `pub(crate)` to `pub(super)` (or `pub(in crate::api_server::response_actions)` where callers cross the execute/rollback subdir boundary). All call sites were already inside `response_actions/`; this restores the file-private intent the split forced wider.
- **P2-3**: drop `TerminateProcessTree` from `supported_edr_response_action` and `default_response_action_reason` (Option A from the review). The dispatcher has no `TerminateProcessTree =>` execute arm and the handler-level allowlist already excludes it from non-dry-run execution -- the supported-list entry was a latent inconsistency. Simulation continues to support `TerminateProcessTree` (audit-stage policy promotion).

## Test plan

- [x] `cargo build --bin clawdstrike-agent` clean
- [x] `cargo clippy --bin clawdstrike-agent -- -D warnings` clean
- [x] `cargo test --bin clawdstrike-agent` matches main baseline exactly (467 passed, 29 pre-existing failures unrelated to this PR)
- [x] `rustfmt --check` clean on all touched files
- [x] Existing `edr_terminate_process_tree_policy_promotion_is_simulation_only` test still passes (simulation continues to support TerminateProcessTree)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only visibility and documentation of existing live-action behavior; no new execution paths or handler logic changes beyond making `TerminateProcessTree` unsupported in the same tables the dispatcher already lacked.
> 
> **Overview**
> Follow-up cleanup on the `response_actions` module split: it tightens the public surface and aligns live-action support with what the dispatcher can actually run.
> 
> **`response_actions/mod.rs`** no longer uses `pub(crate) use super::*;`—only `use super::*;`—so parent `api_server` symbols are visible inside `response_actions` without being re-exported through it (avoiding a circular re-export with `api_server`’s `pub(crate) use response_actions::*`).
> 
> **Visibility:** many internal helpers move from `pub(crate)` to `pub(super)` or `pub(in crate::api_server::response_actions)` where execute/rollback submodules need them, matching file-private intent after the split.
> 
> **`TerminateProcessTree`:** removed from `supported_edr_response_action` and `default_response_action_reason`, with a comment that live execution has no dispatch arm and handlers already block non–dry-run use; **simulation** still includes it via `supported_edr_simulation_action`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cee8b4ae1a0e3b320f173c850a54a87f087c965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->