### PR TITLE
refactor(agent): narrow re-export surface in api_server submodules

### DIFF
--- a/apps/agent/src-tauri/src/api_server/control_sync/ack_postback.rs
+++ b/apps/agent/src-tauri/src/api_server/control_sync/ack_postback.rs
@@ -244,9 +244,9 @@ impl ControlAckPostbackRetrySink {
 }
 
 pub(crate) struct ControlAckPostbackAttemptFailure {
-    pub(crate) http_status: Option<u16>,
-    pub(crate) response_hash: Option<String>,
-    pub(crate) error_hash: Option<String>,
+    http_status: Option<u16>,
+    response_hash: Option<String>,
+    error_hash: Option<String>,
 }
 
 pub(crate) struct ControlAckPostbackRetryAttemptOutcome {

--- a/apps/agent/src-tauri/src/api_server/control_sync/archive_upload.rs
+++ b/apps/agent/src-tauri/src/api_server/control_sync/archive_upload.rs
@@ -35,9 +35,9 @@ pub(crate) fn skipped_control_endpoint_archive_upload_report(
 }
 
 pub(crate) struct ControlArchiveUploadAttemptFailure {
-    pub(crate) http_status: Option<u16>,
-    pub(crate) response_hash: Option<String>,
-    pub(crate) error_hash: Option<String>,
+    http_status: Option<u16>,
+    response_hash: Option<String>,
+    error_hash: Option<String>,
 }
 
 pub(crate) fn required_control_archive_retry_payload_string(

--- a/apps/agent/src-tauri/src/api_server/control_sync/mod.rs
+++ b/apps/agent/src-tauri/src/api_server/control_sync/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) use super::*;
+use super::*;
 
 mod ack_postback;
 mod archive_upload;

--- a/apps/agent/src-tauri/src/api_server/control_sync/receipt_upload.rs
+++ b/apps/agent/src-tauri/src/api_server/control_sync/receipt_upload.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 pub(crate) struct ControlReceiptUploadAttemptFailure {
-    pub(crate) http_status: Option<u16>,
-    pub(crate) response_hash: Option<String>,
-    pub(crate) error_hash: Option<String>,
+    http_status: Option<u16>,
+    response_hash: Option<String>,
+    error_hash: Option<String>,
 }
 
 pub(crate) async fn enqueue_control_receipt_upload_retry(

--- a/apps/agent/src-tauri/src/api_server/evidence_archives/mod.rs
+++ b/apps/agent/src-tauri/src/api_server/evidence_archives/mod.rs
@@ -1,9 +1,23 @@
-pub(crate) use super::*;
+use super::*;
 
 mod helpers;
 mod response;
 mod verify;
 
-pub(crate) use helpers::*;
-pub(crate) use response::*;
-pub(crate) use verify::*;
+// Internal-only re-exports so sibling submodules can resolve each other via
+// `use super::*`. These names stay private to the `evidence_archives` module.
+use helpers::*;
+use response::*;
+use verify::*;
+
+// External surface: only the symbols consumed outside the module are
+// re-exported up to `crate::api_server::*`.
+pub(crate) use helpers::{
+    evidence_bundle_age_seconds, evidence_bundle_record,
+    receipt_family_allows_multiple_archive_members,
+};
+pub(crate) use response::{
+    active_response_evidence_bundle_ids, archive_newest_receipt_timestamp,
+    evidence_bundle_archive_receipts, evidence_bundle_archive_response,
+};
+pub(crate) use verify::evidence_bundle_archive_verification;

--- a/apps/agent/src-tauri/src/api_server/observations/mod.rs
+++ b/apps/agent/src-tauri/src/api_server/observations/mod.rs
@@ -1,6 +1,7 @@
-// Re-export everything from api_server so sub-modules can use `super::*` to access both
-// the api_server context and each other.
-pub(crate) use super::*;
+// Pull api_server's items into this module's namespace so submodules can resolve
+// shared symbols via `use super::*`. Kept non-`pub` so api_server's surface is not
+// re-exported through `crate::api_server::observations`.
+use super::*;
 
 mod builders;
 mod evaluate;

--- a/apps/agent/src-tauri/src/api_server/policy_delta/mod.rs
+++ b/apps/agent/src-tauri/src/api_server/policy_delta/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) use super::*;
+use super::*;
 
 mod apply;
 mod evidence;

--- a/apps/agent/src-tauri/src/api_server/policy_history/mod.rs
+++ b/apps/agent/src-tauri/src/api_server/policy_history/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) use super::*;
+use super::*;
 
 mod causal;
 mod causal_subgraph;


### PR DESCRIPTION
## Summary

Cleans up the three P3 nits flagged in the review of #348 (the 8-file split in `api_server/` and friends). Pure refactor — no behaviour change.

- **P3-1** — three failure structs (`ControlReceiptUploadAttemptFailure`, `ControlAckPostbackAttemptFailure`, `ControlArchiveUploadAttemptFailure`) had their fields promoted to `pub(crate)` even though every constructor lives in the same file. Field privacy restored.
- **P3-2** — `api_server/evidence_archives/mod.rs` had glob re-exports from each submodule. Only seven symbols are consumed outside the module (`evidence_bundle_archive_response`, `archive_newest_receipt_timestamp`, `active_response_evidence_bundle_ids`, `evidence_bundle_archive_receipts`, `evidence_bundle_archive_verification`, `receipt_family_allows_multiple_archive_members`, `evidence_bundle_record`, `evidence_bundle_age_seconds`), so the public surface is now an explicit `pub(crate) use submod::{...}` list. Sibling submodules continue to resolve each other through a non-`pub` `use submod::*` line kept inside `mod.rs`. The other four `mod.rs` files (`control_sync`, `observations`, `policy_history`, `policy_delta`) each had 10+ symbols consumed outside the module, so their globs are kept.
- **P3-3** — the five `api_server/<submod>/mod.rs` files all started with `pub(crate) use super::*;`, which re-exported the parent `api_server` surface back out through the submodule namespace. Demoted to plain `use super::*;`. Sibling sub-files inside each submodule still see parent symbols through their own `use super::*;` lines.

## Test plan

- [x] `cargo build` on the `clawdstrike-agent` crate is clean.
- [x] `cargo clippy -- -D warnings` on the crate is clean.
- [x] `rustfmt --check --edition 2021` on the eight touched files is clean.
- [x] `cargo test` on the crate passes 467 tests and fails 29 — same set documented as pre-existing in `/tmp/review-pr348.md` (`agent_edr_findings_redacts_*` family, `agent_edr_package_manager_events_accept_extended_manager_values`, `macos::collector::tests::merge_samples_*`). No new failures from this PR.

References: review report at `/tmp/review-pr348.md`, original split in #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility-only Rust module layout changes with no logic or API contract changes for callers that already used the explicit exports.
> 
> **Overview**
> This PR **narrows module visibility** in `api_server` after the earlier split: no runtime behavior changes.
> 
> **Control sync failure types** — `ControlReceiptUploadAttemptFailure`, `ControlAckPostbackAttemptFailure`, and `ControlArchiveUploadAttemptFailure` keep `pub(crate)` structs but their `http_status` / `response_hash` / `error_hash` fields are no longer `pub(crate)`; construction and reads stay in the same files.
> 
> **`evidence_archives/mod.rs`** — Submodule glob re-exports are split into private `use helpers::*` / `response::*` / `verify::*` for sibling modules, plus an explicit `pub(crate) use` list of the seven symbols still needed outside the module.
> 
> **Submodule `mod.rs` parents** — In `control_sync`, `observations`, `policy_delta`, `policy_history`, and `evidence_archives`, `pub(crate) use super::*` becomes plain `use super::*` so the parent `api_server` API is not re-exported through submodule paths; other submodules with heavy external use keep their existing `pub(crate) use submod::*` barrels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8cf2c3d94fbee3a7995ad4c2970887f1876b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->