### PR TITLE
refactor(api-server): narrow visibility, scope allow attrs, replace glob re-exports

### DIFF
--- a/apps/agent/src-tauri/src/api_server.rs
+++ b/apps/agent/src-tauri/src/api_server.rs
@@ -12,97 +12,92 @@
 
 // Top-level imports are kept here so the legacy sibling submodules
 // (`control_sync`, `receipts`, `response_actions`, ...) continue to compile
-// via their `use super::*` lines. Some of them are unused at this level but
-// consumed only inside those sibling submodules.
-#![allow(unused_imports)]
+// via their `use super::*` lines. The submodules now own most of the
+// route-level imports — anything still pulled in here is either consumed by
+// a sibling via `super::*`, by the colocated `#[cfg(test)] mod tests`, or by
+// the re-export block below.
 
-use crate::approval::{
-    ApprovalQueue, ApprovalRequestInput, ApprovalResolution, ApprovalResolveInput, ApprovalStatus,
-    ApprovalStatusResponse,
-};
-use crate::daemon::{AuditQueue, DaemonManager, DaemonStatus};
+use crate::approval::{ApprovalResolution, ApprovalStatus};
 use crate::macos::status::{
     CombinedSystemExtensionStatus, ProviderAvailability, ProviderRuntimeState, ProviderStatus,
     SystemExtensionApproval, SystemExtensionInstallState,
 };
-use crate::macos::MacosHostService;
-use crate::openclaw::{
-    GatewayDiscoverInput, GatewayRequestInput, GatewayUpsertRequest, ImportGatewayRequest,
-    OpenClawManager,
-};
-use crate::policy::{evaluate_policy_check, PolicyCheckInput, PolicyCheckOutput};
-use crate::runtime_registry::{
-    register_runtime_agent, resolve_effective_endpoint_agent_id, RuntimeRegistrationInput,
-};
-use crate::session::{SessionManager, SessionState};
-use crate::settings::{IntegrationSettings, RuntimeAgentRegistration, Settings};
-use crate::telemetry_publisher::TelemetryPublisher;
-use crate::updater::{HushdUpdater, OtaStatus};
+use crate::policy::{PolicyCheckInput, PolicyCheckOutput};
+use crate::runtime_registry::resolve_effective_endpoint_agent_id;
+use crate::session::SessionState;
+use crate::settings::Settings;
 use anyhow::{Context, Result};
-use axum::body::Body;
-use axum::extract::DefaultBodyLimit;
-use axum::extract::{Form, Path, Request, State};
-use axum::http::header::{
-    ACCEPT, AUTHORIZATION, CACHE_CONTROL, CONNECTION, CONTENT_TYPE, COOKIE, LOCATION, SET_COOKIE,
-};
-use axum::http::{uri::Authority, HeaderMap, HeaderValue, StatusCode, Uri};
-use axum::middleware::Next;
-use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::response::Html;
-use axum::response::{IntoResponse, Response};
-use axum::routing::{get, patch, post, put};
-use axum::{Json, Router};
-// Receipt*Input types are used only in `mod tests { use super::* }` below.
-#[allow(unused_imports)]
+use axum::http::header::AUTHORIZATION;
+use axum::http::StatusCode;
 use clawdstrike_policy_event::edr::{
-    endpoint_policy_delta_id, endpoint_policy_event_impact_id, endpoint_policy_event_replay_id,
     CausalEdgeKind, CausalGraph, CausalGraphRecorder, CausalNode, CausalNodeKind, CredentialKind,
     DeceptionCleanupReport, DeceptionMaterializationReport, DeceptionPlan, DeceptionRotationReport,
-    DetectionFinding, DetectionSeverity, EndpointDeceptionCleanupReceiptInput,
-    EndpointDeceptionMaterializationReceiptInput, EndpointDeceptionRotationReceiptInput,
-    EndpointDecisionAction, EndpointDecisionActor, EndpointDecisionReceipt,
-    EndpointDetectionReceiptInput, EndpointEvent, EndpointEvidenceBundleManifestReceiptInput,
-    EndpointEvidenceBundleReference, EndpointEvidenceRedactionClass, EndpointFlightRecorder,
-    EndpointFlightRecorderCompactionRecord, EndpointFlightRecorderGraphEdgeIndexEntry,
-    EndpointFlightRecorderGraphNodeIndexEntry, EndpointFlightRecorderHistoryIndexEntry,
-    EndpointGraphReference, EndpointGraphSliceReceiptInput, EndpointObservation,
-    EndpointObservationReceiptInput, EndpointPolicyDecisionReceiptInput,
-    EndpointPolicyDeltaIdInput, EndpointPolicyDeltaReceiptInput, EndpointPolicyEventImpactIdInput,
-    EndpointPolicyEventImpactReceiptInput, EndpointPolicyEventReplayIdInput,
-    EndpointPolicyEventReplayReceiptInput, EndpointPolicySimulationIdentityContext,
-    EndpointPolicySimulationReport, EndpointPolicySimulationRule,
-    EndpointPolicySimulationToolContext, EndpointPolicySnapshot, EndpointProcess,
-    EndpointProviderDegradationReceiptInput, EndpointProviderKind, EndpointProviderState,
-    EndpointReceiptEvidence, EndpointResponseAcknowledgementReceiptInput,
+    DetectionFinding, DetectionSeverity, EndpointDecisionAction, EndpointDecisionActor,
+    EndpointDecisionReceipt, EndpointEvent, EndpointEvidenceRedactionClass, EndpointGraphReference,
+    EndpointObservation, EndpointPolicySimulationReport, EndpointPolicySnapshot, EndpointProcess,
+    EndpointProviderKind, EndpointProviderState, EndpointReceiptEvidence,
     EndpointResponseAcknowledgementReport, EndpointResponseControlCorrelation,
-    EndpointResponseExecutionEffect, EndpointResponseExecutionReceiptInput,
-    EndpointResponseExecutionReport, EndpointResponseExecutionStatus, EndpointResponsePlan,
-    EndpointResponseProcessIdentityBinding, EndpointResponseReceiptInput,
-    EndpointResponseRollbackReceiptInput, EndpointResponseRollbackReport, EndpointSensorState,
-    EndpointSensorStateReceiptInput, EndpointSimulationImpactLevel, EndpointSimulationReceiptInput,
-    EndpointTelemetryPrivacyMode, EndpointTelemetryPrivacyReceiptInput,
-    EndpointTelemetryPrivacyReport, FileOperation, HoneyArtifact, PackageManager,
+    EndpointResponseExecutionEffect, EndpointResponseExecutionReport,
+    EndpointResponseExecutionStatus, EndpointResponsePlan, EndpointResponseProcessIdentityBinding,
+    EndpointResponseRollbackReport, EndpointSensorState, EndpointSimulationImpactLevel,
+    EndpointTelemetryPrivacyMode, EndpointTelemetryPrivacyReport, FileOperation, HoneyArtifact,
     SupplyChainRuntimeGuard,
 };
 use clawdstrike_policy_event::event::PolicyEvent;
 use clawdstrike_policy_event::simulate::replay_events;
-use futures::{Stream, StreamExt, TryStreamExt};
 use hush_core::{canonicalize_json, sha256, Keypair, SignedReceipt};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
-use std::future::Future;
 use std::io::{Read as _, Seek as _, SeekFrom};
-use std::net::{IpAddr, SocketAddr};
-use std::path::{Component, Path as FsPath, PathBuf};
-use std::pin::Pin;
-use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
+use std::net::IpAddr;
+use std::path::{Path as FsPath, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+// The colocated `#[cfg(test)] mod tests` resolves these via `use super::*`.
+// Kept here (rather than in the test files) because the test sources predate
+// the api_server split and rely on every helper being in scope from the
+// parent module.
+#[cfg(test)]
+use crate::approval::ApprovalRequestInput;
+#[cfg(test)]
+use crate::daemon::DaemonManager;
+#[cfg(test)]
+use crate::macos::MacosHostService;
+#[cfg(test)]
+use crate::openclaw::OpenClawManager;
+#[cfg(test)]
+use crate::settings::IntegrationSettings;
+#[cfg(test)]
+use axum::extract::{Path, State};
+#[cfg(test)]
+use axum::http::header::{CONTENT_TYPE, COOKIE, LOCATION, SET_COOKIE};
+#[cfg(test)]
+use axum::http::{HeaderMap, Uri};
+#[cfg(test)]
+use axum::response::{IntoResponse, Response};
+#[cfg(test)]
+use axum::routing::{get, post};
+#[cfg(test)]
+use axum::{Json, Router};
+#[cfg(test)]
+use clawdstrike_policy_event::edr::{
+    EndpointDeceptionCleanupReceiptInput, EndpointEvidenceBundleManifestReceiptInput,
+    EndpointEvidenceBundleReference, EndpointFlightRecorder,
+    EndpointResponseAcknowledgementReceiptInput, EndpointResponseExecutionReceiptInput,
+    EndpointResponseReceiptInput, EndpointResponseRollbackReceiptInput,
+    EndpointSensorStateReceiptInput,
+};
+#[cfg(test)]
+use std::collections::HashMap;
+#[cfg(test)]
+use std::sync::{Mutex as StdMutex, RwLock as StdRwLock};
+#[cfg(test)]
 use tokio::net::TcpListener;
+#[cfg(test)]
 use tokio::sync::{broadcast, Mutex, RwLock};
-use tokio_stream::wrappers::BroadcastStream;
-use tower_http::services::{ServeDir, ServeFile};
 
 pub(crate) use crate::edr::conversion::*;
 pub(crate) use crate::edr::dto::*;
@@ -189,14 +184,12 @@ pub(crate) use crate::edr::ledger::{
 pub(crate) use crate::edr::ledger::{
     EndpointFleetHuntEventOutbox, EndpointFleetHuntEventOutboxEntry,
 };
-// read_*_ledger free functions are used only in mod tests { use super::* }
+// `read_*_ledger` free functions are used only in `mod tests { use super::* }`,
+// but `crate::edr::ledger` re-exports them unconditionally — keep the
+// re-exports here so the unused-warning lives in one place.
 #[allow(unused_imports)]
-pub(crate) use crate::edr::ledger::read_control_ack_postback_retry_ledger;
-#[allow(unused_imports)]
-pub(crate) use crate::edr::ledger::read_control_archive_upload_retry_ledger;
-#[allow(unused_imports)]
-pub(crate) use crate::edr::ledger::read_control_receipt_upload_retry_ledger;
-#[allow(unused_imports)]
-pub(crate) use crate::edr::ledger::read_egress_restriction_ledger;
-#[allow(unused_imports)]
-pub(crate) use crate::edr::ledger::read_fleet_hunt_event_outbox;
+pub(crate) use crate::edr::ledger::{
+    read_control_ack_postback_retry_ledger, read_control_archive_upload_retry_ledger,
+    read_control_receipt_upload_retry_ledger, read_egress_restriction_ledger,
+    read_fleet_hunt_event_outbox,
+};

--- a/apps/agent/src-tauri/src/api_server/state.rs
+++ b/apps/agent/src-tauri/src/api_server/state.rs
@@ -30,80 +30,91 @@ use clawdstrike_policy_event::edr::{
     EndpointFlightRecorder,
 };
 
-pub(crate) const HUSHD_AUTHORIZATION_HEADER: &str = "x-hushd-authorization";
-pub(crate) const AGENT_AUTH_COOKIE_NAME: &str = "clawdstrike_agent_auth";
-pub(crate) const POLICY_VERSION_CACHE_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
-pub(crate) const POLICY_VERSION_FETCH_TIMEOUT: Duration = Duration::from_millis(200);
-pub(crate) const POLICY_VERSION_REFRESH_IN_FLIGHT_TIMEOUT: Duration = Duration::from_secs(20);
-pub(crate) const AGENT_API_MAX_BODY_BYTES: usize = 256 * 1024;
-pub(crate) const BROKER_MUTATION_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
-pub(crate) const EDR_MAX_OBSERVATIONS_PER_REQUEST: usize = 10_000;
+// Constants below are narrowed with `pub(in crate::api_server)` when they are
+// only referenced from within this module tree. The ones that escape (used by
+// `crate::edr::*` ledger and handler code) stay `pub(crate)`.
+pub(in crate::api_server) const HUSHD_AUTHORIZATION_HEADER: &str = "x-hushd-authorization";
+pub(in crate::api_server) const AGENT_AUTH_COOKIE_NAME: &str = "clawdstrike_agent_auth";
+pub(in crate::api_server) const POLICY_VERSION_CACHE_REFRESH_INTERVAL: Duration =
+    Duration::from_secs(5);
+pub(in crate::api_server) const POLICY_VERSION_FETCH_TIMEOUT: Duration = Duration::from_millis(200);
+pub(in crate::api_server) const POLICY_VERSION_REFRESH_IN_FLIGHT_TIMEOUT: Duration =
+    Duration::from_secs(20);
+pub(in crate::api_server) const AGENT_API_MAX_BODY_BYTES: usize = 256 * 1024;
+pub(in crate::api_server) const BROKER_MUTATION_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+pub(in crate::api_server) const EDR_MAX_OBSERVATIONS_PER_REQUEST: usize = 10_000;
 pub(crate) const EDR_MAX_HONEY_ARTIFACTS_PER_REQUEST: usize = 1_000;
 pub(crate) const EDR_MAX_STORED_FINDINGS: usize = 10_000;
 pub(crate) const EDR_MAX_CONTROL_ACK_POSTBACK_RETRIES: usize = 1_000;
 pub(crate) const EDR_MAX_CONTROL_ARCHIVE_UPLOAD_RETRIES: usize = 1_000;
 pub(crate) const EDR_MAX_CONTROL_RECEIPT_UPLOAD_RETRIES: usize = 1_000;
 pub(crate) const EDR_MAX_FLEET_HUNT_EVENT_OUTBOX: usize = 1_000;
-pub(crate) const EDR_CONTROL_ACK_RETRY_INITIAL_BACKOFF_SECONDS: i64 = 30;
-pub(crate) const EDR_CONTROL_ACK_RETRY_MAX_BACKOFF_SECONDS: i64 = 300;
-pub(crate) const EDR_CONTROL_ACK_RETRY_DRAIN_INTERVAL: Duration = Duration::from_secs(30);
-pub(crate) const EDR_RESPONSE_EXPIRATION_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
-pub(crate) const EDR_CONTROL_ACK_RETRY_BACKGROUND_LIMIT: usize = 25;
-pub(crate) const EDR_CONTROL_RECEIPT_UPLOAD_BACKGROUND_LIMIT: usize = 25;
-pub(crate) const EDR_CONTROL_RECEIPT_UPLOAD_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
-pub(crate) const EDR_CONTROL_ACK_STATUS_ALLOWLIST: &str =
+pub(in crate::api_server) const EDR_CONTROL_ACK_RETRY_INITIAL_BACKOFF_SECONDS: i64 = 30;
+pub(in crate::api_server) const EDR_CONTROL_ACK_RETRY_MAX_BACKOFF_SECONDS: i64 = 300;
+pub(in crate::api_server) const EDR_CONTROL_ACK_RETRY_DRAIN_INTERVAL: Duration =
+    Duration::from_secs(30);
+pub(in crate::api_server) const EDR_RESPONSE_EXPIRATION_SWEEP_INTERVAL: Duration =
+    Duration::from_secs(30);
+pub(in crate::api_server) const EDR_CONTROL_ACK_RETRY_BACKGROUND_LIMIT: usize = 25;
+pub(in crate::api_server) const EDR_CONTROL_RECEIPT_UPLOAD_BACKGROUND_LIMIT: usize = 25;
+pub(in crate::api_server) const EDR_CONTROL_RECEIPT_UPLOAD_REQUEST_TIMEOUT: Duration =
+    Duration::from_secs(2);
+pub(in crate::api_server) const EDR_CONTROL_ACK_STATUS_ALLOWLIST: &str =
     "acknowledged, rejected, failed, expired, rolled_back";
-pub(crate) const EDR_CONTROL_ACK_TARGET_KIND_ALLOWLIST: &str =
+pub(in crate::api_server) const EDR_CONTROL_ACK_TARGET_KIND_ALLOWLIST: &str =
     "endpoint, runtime, session, principal, grant, swarm, project";
 pub(crate) const EDR_MAX_CAUSAL_SUBGRAPH_DEPTH: usize = 64;
 pub(crate) const EDR_DEFAULT_RECEIPT_QUERY_LIMIT: usize = 100;
 pub(crate) const EDR_MAX_RECEIPT_QUERY_LIMIT: usize = 1_000;
-pub(crate) const EDR_DEFAULT_RESPONSE_TTL_SECONDS: u64 = 600;
-pub(crate) const EDR_MAX_RESPONSE_TTL_SECONDS: u64 = 3_600;
-pub(crate) const EDR_MAX_RESPONSE_REASON_BYTES: usize = 1024;
-pub(crate) const EDR_MAX_RESPONSE_ACTOR_FIELD_BYTES: usize = 256;
-pub(crate) const EDR_MAX_RAW_ARTIFACT_APPROVAL_ID_BYTES: usize = 128;
-pub(crate) const EDR_MAX_RAW_ARTIFACT_APPROVAL_REASON_BYTES: usize = 1024;
-pub(crate) const EDR_RAW_ARTIFACT_UPLOAD_GUARD: &str = "endpoint.telemetry.raw_artifact_upload";
+pub(in crate::api_server) const EDR_DEFAULT_RESPONSE_TTL_SECONDS: u64 = 600;
+pub(in crate::api_server) const EDR_MAX_RESPONSE_TTL_SECONDS: u64 = 3_600;
+pub(in crate::api_server) const EDR_MAX_RESPONSE_REASON_BYTES: usize = 1024;
+pub(in crate::api_server) const EDR_MAX_RESPONSE_ACTOR_FIELD_BYTES: usize = 256;
+pub(in crate::api_server) const EDR_MAX_RAW_ARTIFACT_APPROVAL_ID_BYTES: usize = 128;
+pub(in crate::api_server) const EDR_MAX_RAW_ARTIFACT_APPROVAL_REASON_BYTES: usize = 1024;
+pub(in crate::api_server) const EDR_RAW_ARTIFACT_UPLOAD_GUARD: &str =
+    "endpoint.telemetry.raw_artifact_upload";
 pub(crate) const EDR_DEFAULT_RESPONSE_EXECUTION_QUERY_LIMIT: usize = 100;
 pub(crate) const EDR_MAX_RESPONSE_EXECUTION_QUERY_LIMIT: usize = 1_000;
 pub(crate) const EDR_NETWORK_EXTENSION_EGRESS_POLICY_SCHEMA_VERSION: u32 = 1;
 pub(crate) const EDR_POLICY_DELTA_SCHEMA_VERSION: &str = "clawdstrike.endpoint_policy_delta.v1";
 pub(crate) const EDR_DEFAULT_POLICY_EVENT_IMPACT_CAUSAL_DEPTH: usize = 3;
-pub(crate) const EDR_MAX_POLICY_EVENT_IMPACT_CONTEXTS: usize = 16;
-pub(crate) const EDR_MAX_POLICY_EVENT_IMPACT_CHAINS_PER_CONTEXT: usize = 8;
-pub(crate) const EDR_MAX_POLICY_EVENT_IMPACT_CHAIN_DRIVER_SAMPLES: usize = 5;
-pub(crate) const EDR_MAX_POLICY_EVENT_IMPACT_PROMOTION_SUGGESTIONS: usize = 16;
-pub(crate) const EDR_MAX_POLICY_EVENT_IMPACT_BREAKAGE_DRIVERS: usize = 8;
-pub(crate) const EDR_MAX_POLICY_EVENT_IMPACT_VALIDATION_WINDOW_SECONDS: u64 = 86_400;
-pub(crate) const EDR_CROSS_WINDOW_PROMOTION_VALIDATION_CACHE_LIMIT: usize = 128;
-pub(crate) const EDR_CROSS_WINDOW_PROMOTION_VALIDATION_MAX_AGE_SECONDS: i64 = 86_400;
-pub(crate) const EDR_MAX_AUTO_FLEET_AGENT_SECRET_TOUCHES_PER_BATCH: usize = 100;
-pub(crate) const EDR_MAX_AUTO_FLEET_HUNT_EVENT_OUTBOX_RETRIES_PER_BATCH: usize = 100;
-pub(crate) const EDR_FLEET_AGENT_SECRET_TOUCH_SYNC_INTERVAL: Duration = Duration::from_secs(60);
-pub(crate) const EDR_DEFAULT_PROVIDER_ACK_TIMEOUT_MS: u64 = 750;
-pub(crate) const EDR_MAX_PROVIDER_ACK_TIMEOUT_MS: u64 = 5_000;
-pub(crate) const EDR_PROVIDER_ACK_POLL_INTERVAL: Duration = Duration::from_millis(50);
-pub(crate) const APPROVAL_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
-pub(crate) const APPROVAL_RATE_LIMIT_BURST_WINDOW: Duration = Duration::from_secs(1);
-pub(crate) const APPROVAL_RATE_LIMIT_PER_MINUTE: usize = 30;
-pub(crate) const APPROVAL_RATE_LIMIT_BURST: usize = 10;
-pub(crate) const ROUTE_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
-pub(crate) const ROUTE_RATE_LIMIT_UI_BOOTSTRAP_START: usize = 20;
-pub(crate) const ROUTE_RATE_LIMIT_UI_BOOTSTRAP_VERIFY: usize = 60;
-pub(crate) const ROUTE_RATE_LIMIT_POLICY_CHECK: usize = 1200;
-pub(crate) const ROUTE_RATE_LIMIT_INTEGRATION_TEST: usize = 30;
-pub(crate) const ROUTE_RATE_LIMIT_OPENCLAW_REQUEST: usize = 120;
-pub(crate) const UI_BOOTSTRAP_TTL: Duration = Duration::from_secs(60);
-pub(crate) const UI_BOOTSTRAP_MAX_ATTEMPTS: u8 = 5;
-pub(crate) const UI_BOOTSTRAP_MAX_SESSIONS: usize = 32;
-pub(crate) const LOCAL_API_TOKEN_ROTATION_MIN_HOURS: u32 = 1;
-pub(crate) const LOCAL_API_TOKEN_ROTATION_MAX_HOURS: u32 = 24 * 30;
-pub(crate) const LOCAL_API_TOKEN_GRACE_MIN_MINUTES: u32 = 1;
-pub(crate) const LOCAL_API_TOKEN_GRACE_MAX_MINUTES: u32 = 120;
-pub(crate) const LOCAL_API_MTLS_MIN_PORT: u16 = 1024;
-pub(crate) const OTA_CHECK_INTERVAL_MIN_MINUTES: u32 = 5;
-pub(crate) const OTA_CHECK_INTERVAL_MAX_MINUTES: u32 = 60 * 24 * 7;
+pub(in crate::api_server) const EDR_MAX_POLICY_EVENT_IMPACT_CONTEXTS: usize = 16;
+pub(in crate::api_server) const EDR_MAX_POLICY_EVENT_IMPACT_CHAINS_PER_CONTEXT: usize = 8;
+pub(in crate::api_server) const EDR_MAX_POLICY_EVENT_IMPACT_CHAIN_DRIVER_SAMPLES: usize = 5;
+pub(in crate::api_server) const EDR_MAX_POLICY_EVENT_IMPACT_PROMOTION_SUGGESTIONS: usize = 16;
+pub(in crate::api_server) const EDR_MAX_POLICY_EVENT_IMPACT_BREAKAGE_DRIVERS: usize = 8;
+pub(in crate::api_server) const EDR_MAX_POLICY_EVENT_IMPACT_VALIDATION_WINDOW_SECONDS: u64 = 86_400;
+pub(in crate::api_server) const EDR_CROSS_WINDOW_PROMOTION_VALIDATION_CACHE_LIMIT: usize = 128;
+pub(in crate::api_server) const EDR_CROSS_WINDOW_PROMOTION_VALIDATION_MAX_AGE_SECONDS: i64 = 86_400;
+pub(in crate::api_server) const EDR_MAX_AUTO_FLEET_AGENT_SECRET_TOUCHES_PER_BATCH: usize = 100;
+pub(in crate::api_server) const EDR_MAX_AUTO_FLEET_HUNT_EVENT_OUTBOX_RETRIES_PER_BATCH: usize = 100;
+pub(in crate::api_server) const EDR_FLEET_AGENT_SECRET_TOUCH_SYNC_INTERVAL: Duration =
+    Duration::from_secs(60);
+pub(in crate::api_server) const EDR_DEFAULT_PROVIDER_ACK_TIMEOUT_MS: u64 = 750;
+pub(in crate::api_server) const EDR_MAX_PROVIDER_ACK_TIMEOUT_MS: u64 = 5_000;
+pub(in crate::api_server) const EDR_PROVIDER_ACK_POLL_INTERVAL: Duration =
+    Duration::from_millis(50);
+pub(in crate::api_server) const APPROVAL_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+pub(in crate::api_server) const APPROVAL_RATE_LIMIT_BURST_WINDOW: Duration = Duration::from_secs(1);
+pub(in crate::api_server) const APPROVAL_RATE_LIMIT_PER_MINUTE: usize = 30;
+pub(in crate::api_server) const APPROVAL_RATE_LIMIT_BURST: usize = 10;
+pub(in crate::api_server) const ROUTE_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+pub(in crate::api_server) const ROUTE_RATE_LIMIT_UI_BOOTSTRAP_START: usize = 20;
+pub(in crate::api_server) const ROUTE_RATE_LIMIT_UI_BOOTSTRAP_VERIFY: usize = 60;
+pub(in crate::api_server) const ROUTE_RATE_LIMIT_POLICY_CHECK: usize = 1200;
+pub(in crate::api_server) const ROUTE_RATE_LIMIT_INTEGRATION_TEST: usize = 30;
+pub(in crate::api_server) const ROUTE_RATE_LIMIT_OPENCLAW_REQUEST: usize = 120;
+pub(in crate::api_server) const UI_BOOTSTRAP_TTL: Duration = Duration::from_secs(60);
+pub(in crate::api_server) const UI_BOOTSTRAP_MAX_ATTEMPTS: u8 = 5;
+pub(in crate::api_server) const UI_BOOTSTRAP_MAX_SESSIONS: usize = 32;
+pub(in crate::api_server) const LOCAL_API_TOKEN_ROTATION_MIN_HOURS: u32 = 1;
+pub(in crate::api_server) const LOCAL_API_TOKEN_ROTATION_MAX_HOURS: u32 = 24 * 30;
+pub(in crate::api_server) const LOCAL_API_TOKEN_GRACE_MIN_MINUTES: u32 = 1;
+pub(in crate::api_server) const LOCAL_API_TOKEN_GRACE_MAX_MINUTES: u32 = 120;
+pub(in crate::api_server) const LOCAL_API_MTLS_MIN_PORT: u16 = 1024;
+pub(in crate::api_server) const OTA_CHECK_INTERVAL_MIN_MINUTES: u32 = 5;
+pub(in crate::api_server) const OTA_CHECK_INTERVAL_MAX_MINUTES: u32 = 60 * 24 * 7;
 
 #[derive(Clone)]
 pub struct AgentApiServer {


### PR DESCRIPTION
## Summary

Follow-up to #349 addressing P2 nits flagged by the bot-class review:

- **P2-2 (over-broad `#![allow(unused_imports)]`)**: removed the file-level allow on `apps/agent/src-tauri/src/api_server.rs` and pruned the dozens of `use crate::...; use axum::...; use std::...;` declarations the 202-line facade no longer needs. The colocated `#[cfg(test)] mod tests` still consumes a handful of types via `use super::*`, so those imports are kept behind `#[cfg(test)]` rather than re-allowing the entire file. The five `read_*_ledger` re-exports collapse into a single explicit list under one narrow `#[allow(unused_imports)]` (the underlying ledger mod re-exports them unconditionally, so this is the one place the warning has to live).
- **P2-1 (over-broad `pub(crate)` promotions)**: narrowed roughly sixty `const` definitions in `api_server/state.rs` from `pub(crate)` to `pub(in crate::api_server)`. The constants that `crate::edr::*` ledger and handler code actually reaches (EDR retry caps, the policy-delta schema version, receipt/response query limits, the network-extension egress policy schema version, the honey-artifact + stored-finding caps, etc.) stay crate-visible. Everything else (rate-limit thresholds, UI bootstrap TTLs, OTA intervals, body-byte caps, local-API token windows, policy-version cache timings) is no longer exported past the api_server module tree.
- **P2-3 (glob re-exports)**: investigated and confirmed that every new submodule (`default_paths`, `fleet_publish`, `helpers`, `middleware`, `proxy`, `routes`, `state`, `ui_bootstrap`, `util`) exposes more than the 8-symbol threshold mentioned in the cleanup brief, and every one of them has at least one symbol consumed by `crate::edr::*` outside `api_server/`. Leaving the existing globs in place per the brief's guidance ("If a submodule has many (>=8) re-exported symbols, leave the glob").

## Test plan

- [x] `cargo build --bin clawdstrike-agent --offline` — clean
- [x] `cargo clippy --bin clawdstrike-agent --offline -- -D warnings` — clean
- [x] `cargo check --tests --bin clawdstrike-agent --offline` — clean
- [x] `rustfmt --check` on the two modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and visibility cleanup only; limits and auth behavior are unchanged, with build/clippy/test checks reported clean.
> 
> **Overview**
> Tightens the post-split `api_server` module boundary without changing runtime behavior.
> 
> In **`api_server.rs`**, the file-wide `#![allow(unused_imports)]` is removed and the root import list is trimmed to what legacy submodules and the colocated `#[cfg(test)] mod tests` still need via `use super::*`. Test-only types (Axum extractors, extra EDR receipt inputs, `DaemonManager`, etc.) move behind **`#[cfg(test)]`** instead of silencing the whole file. The five `read_*_ledger` re-exports are grouped under a **single** `#[allow(unused_imports)]` with a short comment explaining why the warning must live there.
> 
> In **`api_server/state.rs`**, roughly **sixty** configuration constants that are only used inside the `api_server` tree are narrowed from **`pub(crate)`** to **`pub(in crate::api_server)`** (rate limits, UI bootstrap, OTA intervals, body limits, policy-version cache timings, many EDR tuning knobs). Constants still referenced from **`crate::edr::*`** (ledger caps, receipt/response query limits, policy-delta schema version, honey-artifact limits, etc.) stay **`pub(crate)`**.
> 
> Glob re-exports for the new submodules are **unchanged** (still required for `edr` and the existing facade).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb1d3c1e0707ce4e9b32c6e67cb039ad8fe977f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->