### PR TITLE
fix(security): bump tar 0.4.45→0.4.46 in agent/workbench Tauri locks

### DIFF
--- a/apps/agent/src-tauri/Cargo.lock
+++ b/apps/agent/src-tauri/Cargo.lock
@@ -5342,9 +5342,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/apps/workbench/src-tauri/Cargo.lock
+++ b/apps/workbench/src-tauri/Cargo.lock
@@ -6055,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## What

Surgical lockfile patch bumping `tar` 0.4.45 → 0.4.46 in the agent and workbench Tauri lockfiles.

Resolves Dependabot alerts **#395** and **#396** (RUSTSEC: tar PAX-header desynchronization, medium).

## Why it's safe

- `tar` 0.4.46 is **dependency-identical** to 0.4.45 (`filetime`, `libc`, `xattr`) — only the version + checksum lines change.
- The root and desktop locks already resolve `tar` 0.4.46; this just brings agent/workbench in line.
- No re-resolution / no other dependency churn.

## Remaining Rust alerts

The other open Dependabot Rust alerts (rustls-webpki, yamux, glib, rand) are transitive deps blocked on upstream/major upgrades — tracked separately (see the deferred-dependency tracking issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch bump with no dependency graph changes; low runtime impact beyond the security fix in `tar`.
> 
> **Overview**
> Bumps the transitive **`tar`** crate from **0.4.45** to **0.4.46** in `apps/agent/src-tauri/Cargo.lock` and `apps/workbench/src-tauri/Cargo.lock` (version and checksum only; dependency set unchanged).
> 
> This addresses **RUSTSEC** / Dependabot alerts for PAX-header desynchronization in `tar` and aligns those Tauri apps with the rest of the repo, which already pins **0.4.46**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8d272220de99b110b9467b6a9aa3e8b76c0912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->